### PR TITLE
Shade: Put all VU meters in a fixed size parent widget

### DIFF
--- a/res/skins/Shade/auxiliary.xml
+++ b/res/skins/Shade/auxiliary.xml
@@ -24,19 +24,23 @@
       Visual - Volume level display
       **********************************************
       -->
-      <VuMeter>
-        <TooltipId>auxiliary_VuMeter</TooltipId>
-        <PathVu>skin:/style/volume_display_microphone_over.png</PathVu>
-        <PathBack>skin:/style/volume_display_microphone.png</PathBack>
+      <WidgetGroup>
         <Pos>99,14</Pos>
-        <PeakHoldSize>5</PeakHoldSize>
-        <PeakHoldTime>500</PeakHoldTime>
-        <PeakFallTime>50</PeakFallTime>
-        <PeakFallStep>2</PeakFallStep>
-        <Connection>
-          <ConfigKey>[Auxiliary<Variable name="auxnum"/>],VuMeter</ConfigKey>
-        </Connection>
-      </VuMeter>
+        <Children>
+          <VuMeter>
+            <TooltipId>auxiliary_VuMeter</TooltipId>
+            <PathVu>skin:/style/volume_display_microphone_over.png</PathVu>
+            <PathBack>skin:/style/volume_display_microphone.png</PathBack>
+            <PeakHoldSize>5</PeakHoldSize>
+            <PeakHoldTime>500</PeakHoldTime>
+            <PeakFallTime>50</PeakFallTime>
+            <PeakFallStep>2</PeakFallStep>
+            <Connection>
+              <ConfigKey>[Auxiliary<Variable name="auxnum"/>],VuMeter</ConfigKey>
+            </Connection>
+          </VuMeter>
+        </Children>
+      </WidgetGroup>
 
       <Knob>
         <TooltipId>auxiliary_pregain</TooltipId>

--- a/res/skins/Shade/microphone.xml
+++ b/res/skins/Shade/microphone.xml
@@ -25,19 +25,23 @@
       Visual - Volume level display
       **********************************************
       -->
-      <VuMeter>
-        <TooltipId>microphone_VuMeter</TooltipId>
-        <PathVu>skin:/style/volume_display_microphone_over.png</PathVu>
-        <PathBack>skin:/style/volume_display_microphone.png</PathBack>
+      <WidgetGroup>
         <Pos>82,14</Pos>
-        <PeakHoldSize>5</PeakHoldSize>
-        <PeakHoldTime>500</PeakHoldTime>
-        <PeakFallTime>50</PeakFallTime>
-        <PeakFallStep>2</PeakFallStep>
-        <Connection>
-          <ConfigKey>[Microphone<Variable name="micnum"/>],VuMeter</ConfigKey>
-        </Connection>
-      </VuMeter>
+        <Children>
+          <VuMeter>
+            <TooltipId>microphone_VuMeter</TooltipId>
+            <PathVu>skin:/style/volume_display_microphone_over.png</PathVu>
+            <PathBack>skin:/style/volume_display_microphone.png</PathBack>
+            <PeakHoldSize>5</PeakHoldSize>
+            <PeakHoldTime>500</PeakHoldTime>
+            <PeakFallTime>50</PeakFallTime>
+            <PeakFallStep>2</PeakFallStep>
+            <Connection>
+              <ConfigKey>[Microphone<Variable name="micnum"/>],VuMeter</ConfigKey>
+            </Connection>
+          </VuMeter>
+        </Children>
+      </WidgetGroup>
 
       <!--
       **********************************************

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -504,22 +504,27 @@
                 </Connection>
               </StatusLight>
 
-              <VuMeter>
+              <WidgetGroup>
                 <Pos>113,28</Pos>
-                <Style>WVuMeter { background-color: #626f87; }</Style>
-                <TooltipId>audio_latency_usage</TooltipId>
-                <MinimumSize>26,1</MinimumSize>
-                <MaximumSize>26,1</MaximumSize>
-                <PathVu>audio_latency/audio_latency_usage.png</PathVu>
-                <PeakHoldSize>26</PeakHoldSize>
-                <PeakHoldTime>500</PeakHoldTime>
-                <PeakFallTime>50</PeakFallTime>
-                <PeakFallStep>1</PeakFallStep>
-                <Horizontal>true</Horizontal>
-                <Connection>
-                  <ConfigKey>[Master],audio_latency_usage</ConfigKey>
-                </Connection>
-              </VuMeter>
+                <Children>
+                  <VuMeter>
+                    <Pos>113,28</Pos>
+                    <Style>WVuMeter { background-color: #626f87; }</Style>
+                    <TooltipId>audio_latency_usage</TooltipId>
+                    <MinimumSize>26,1</MinimumSize>
+                    <MaximumSize>26,1</MaximumSize>
+                    <PathVu>audio_latency/audio_latency_usage.png</PathVu>
+                    <PeakHoldSize>26</PeakHoldSize>
+                    <PeakHoldTime>500</PeakHoldTime>
+                    <PeakFallTime>50</PeakFallTime>
+                    <PeakFallStep>1</PeakFallStep>
+                    <Horizontal>true</Horizontal>
+                    <Connection>
+                      <ConfigKey>[Master],audio_latency_usage</ConfigKey>
+                    </Connection>
+                  </VuMeter>
+                </Children>
+              </WidgetGroup>
 
               <PushButton>
                 <NumberStates>5</NumberStates>
@@ -792,62 +797,76 @@
               Visual - Volume level display
               **********************************************
               -->
-              <VuMeter>
-                <TooltipId>channel_VuMeter</TooltipId>
-                <PathVu>skin:/style/volume_display_over.png</PathVu>
-                <PathBack>skin:/style/volume_display.png</PathBack>
+              <WidgetGroup>
                 <Pos>107,76</Pos>
-                <Horizontal>false</Horizontal>
-                <PeakHoldSize>5</PeakHoldSize>
-                <PeakHoldTime>500</PeakHoldTime>
-                <PeakFallTime>50</PeakFallTime>
-                <PeakFallStep>2</PeakFallStep>
-                <Connection>
-                  <ConfigKey>[Channel1],VuMeter</ConfigKey>
-                </Connection>
-              </VuMeter>
-              <VuMeter>
-                <TooltipId>channel_VuMeter</TooltipId>
-                <PathVu>skin:/style/volume_display_over.png</PathVu>
-                <PathBack>skin:/style/volume_display.png</PathBack>
+                <Children>
+                  <VuMeter>
+                    <TooltipId>channel_VuMeter</TooltipId>
+                    <PathVu>skin:/style/volume_display_over.png</PathVu>
+                    <PathBack>skin:/style/volume_display.png</PathBack>
+                    <Horizontal>false</Horizontal>
+                    <PeakHoldSize>5</PeakHoldSize>
+                    <PeakHoldTime>500</PeakHoldTime>
+                    <PeakFallTime>50</PeakFallTime>
+                    <PeakFallStep>2</PeakFallStep>
+                    <Connection>
+                      <ConfigKey>[Channel1],VuMeter</ConfigKey>
+                    </Connection>
+                  </VuMeter>
+                </Children>
+              </WidgetGroup>
+              <WidgetGroup>
                 <Pos>143,76</Pos>
-                <Horizontal>false</Horizontal>
-                <PeakHoldSize>5</PeakHoldSize>
-                <PeakHoldTime>500</PeakHoldTime>
-                <PeakFallTime>50</PeakFallTime>
-                <PeakFallStep>2</PeakFallStep>
-                <Connection>
-                  <ConfigKey>[Channel2],VuMeter</ConfigKey>
-                </Connection>
-              </VuMeter>
-
-              <VuMeter>
-                <TooltipId>master_VuMeterL</TooltipId>
-                <PathVu>skin:/style/volume_display_master_over.png</PathVu>
-                <PathBack>skin:/style/volume_display_master.png</PathBack>
+                <Children>
+                  <VuMeter>
+                    <TooltipId>channel_VuMeter</TooltipId>
+                    <PathVu>skin:/style/volume_display_over.png</PathVu>
+                    <PathBack>skin:/style/volume_display.png</PathBack>
+                    <Horizontal>false</Horizontal>
+                    <PeakHoldSize>5</PeakHoldSize>
+                    <PeakHoldTime>500</PeakHoldTime>
+                    <PeakFallTime>50</PeakFallTime>
+                    <PeakFallStep>2</PeakFallStep>
+                    <Connection>
+                      <ConfigKey>[Channel2],VuMeter</ConfigKey>
+                    </Connection>
+                  </VuMeter>
+                </Children>
+              </WidgetGroup>
+              <WidgetGroup>
                 <Pos>122,76</Pos>
-                <PeakHoldSize>5</PeakHoldSize>
-                <PeakHoldTime>500</PeakHoldTime>
-                <PeakFallTime>50</PeakFallTime>
-                <PeakFallStep>2</PeakFallStep>
-                <Connection>
-                  <ConfigKey>[Master],VuMeterL</ConfigKey>
-                </Connection>
-              </VuMeter>
-              <VuMeter>
-                <TooltipId>master_VuMeterR</TooltipId>
-                <PathVu>skin:/style/volume_display_master_over.png</PathVu>
-                <PathBack>skin:/style/volume_display_master.png</PathBack>
+                <Children>
+                  <VuMeter>
+                    <TooltipId>master_VuMeterL</TooltipId>
+                    <PathVu>skin:/style/volume_display_master_over.png</PathVu>
+                    <PathBack>skin:/style/volume_display_master.png</PathBack>
+                    <PeakHoldSize>5</PeakHoldSize>
+                    <PeakHoldTime>500</PeakHoldTime>
+                    <PeakFallTime>50</PeakFallTime>
+                    <PeakFallStep>2</PeakFallStep>
+                    <Connection>
+                      <ConfigKey>[Master],VuMeterL</ConfigKey>
+                    </Connection>
+                  </VuMeter>
+                </Children>
+              </WidgetGroup>
+              <WidgetGroup>
                 <Pos>128,76</Pos>
-                <PeakHoldSize>5</PeakHoldSize>
-                <PeakHoldTime>500</PeakHoldTime>
-                <PeakFallTime>50</PeakFallTime>
-                <PeakFallStep>2</PeakFallStep>
-                <Connection>
-                  <ConfigKey>[Master],VuMeterR</ConfigKey>
-                </Connection>
-              </VuMeter>
-
+                <Children>
+                  <VuMeter>
+                    <TooltipId>master_VuMeterR</TooltipId>
+                    <PathVu>skin:/style/volume_display_master_over.png</PathVu>
+                    <PathBack>skin:/style/volume_display_master.png</PathBack>
+                    <PeakHoldSize>5</PeakHoldSize>
+                    <PeakHoldTime>500</PeakHoldTime>
+                    <PeakFallTime>50</PeakFallTime>
+                    <PeakFallStep>2</PeakFallStep>
+                    <Connection>
+                      <ConfigKey>[Master],VuMeterR</ConfigKey>
+                    </Connection>
+                  </VuMeter>
+                </Children>
+              </WidgetGroup>
               <!--
               **********************************************
               Visual- Volume peak indicator

--- a/res/skins/Shade/preview_deck.xml
+++ b/res/skins/Shade/preview_deck.xml
@@ -215,21 +215,25 @@
                       <ConfigKey>[PreviewDeck1],PeakIndicator</ConfigKey>
                     </Connection>
                   </StatusLight>
-                  <VuMeter>
-                    <TooltipId>sampler_VuMeter</TooltipId>
-                    <PathVu>skin:/style/volume_display_previewdeck_over.png</PathVu>
-                    <PathBack>skin:/style/volume_display_previewdeck.png</PathBack>
+                  <WidgetGroup>
                     <Pos>2,11</Pos>
                     <Size>5f,41f</Size>
-                    <Horizontal>false</Horizontal>
-                    <PeakHoldSize>5</PeakHoldSize>
-                    <PeakHoldTime>500</PeakHoldTime>
-                    <PeakFallTime>50</PeakFallTime>
-                    <PeakFallStep>2</PeakFallStep>
-                    <Connection>
-                      <ConfigKey>[PreviewDeck1],VuMeter</ConfigKey>
-                    </Connection>
-                  </VuMeter>
+                    <Children>
+                      <VuMeter>
+                        <TooltipId>sampler_VuMeter</TooltipId>
+                        <PathVu>skin:/style/volume_display_previewdeck_over.png</PathVu>
+                        <PathBack>skin:/style/volume_display_previewdeck.png</PathBack>
+                        <Horizontal>false</Horizontal>
+                        <PeakHoldSize>5</PeakHoldSize>
+                        <PeakHoldTime>500</PeakHoldTime>
+                        <PeakFallTime>50</PeakFallTime>
+                        <PeakFallStep>2</PeakFallStep>
+                        <Connection>
+                          <ConfigKey>[PreviewDeck1],VuMeter</ConfigKey>
+                        </Connection>
+                      </VuMeter>
+                    </Children>
+                  </WidgetGroup>
                 </Children>
               </WidgetGroup>
 

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -384,6 +384,24 @@
               <ConfigKey><Variable name="group"/>,PeakIndicator</ConfigKey>
             </Connection>
           </StatusLight>
+          <WidgetGroup>
+            <Pos>3,24</Pos>
+            <Children>
+              <VuMeter>
+                <TooltipId>sampler_VuMeter</TooltipId>
+                <PathVu>skin:/style/volume_display_sampler_over.png</PathVu>
+                <PathBack>skin:/style/volume_display_sampler.png</PathBack>
+                <Horizontal>false</Horizontal>
+                <PeakHoldSize>5</PeakHoldSize>
+                <PeakHoldTime>500</PeakHoldTime>
+                <PeakFallTime>50</PeakFallTime>
+                <PeakFallStep>2</PeakFallStep>
+                <Connection>
+                  <ConfigKey><Variable name="group"/>,VuMeter</ConfigKey>
+                </Connection>
+              </VuMeter>
+            </Children>
+          </WidgetGroup>
           <VuMeter>
             <TooltipId>sampler_VuMeter</TooltipId>
             <PathVu>skin:/style/volume_display_sampler_over.png</PathVu>


### PR DESCRIPTION
This fixed the special Shade issues. By putting the freely placed Vu meters into fixed sized patent Widgets. 
