### PR TITLE
PR that makes UI with QOpenGL waveform responsive on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,15 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 option(QT6 "Build with Qt6" OFF)
+if(APPLE)
+option(QOPENGL "Use QOpenGL... classes instead of QGLWidget" ON)
+else()
+option(QOPENGL "Use QOpenGL... classes instead of QGLWidget" OFF)
+endif()
+
+if(QOPENGL)
+    add_compile_definitions(MIXXX_USE_QOPENGL)
+endif()
 
 if(APPLE)
   if(QT6)
@@ -1113,7 +1122,6 @@ else()
     src/waveform/renderers/waveformrendermarkrange.cpp
     src/waveform/renderers/waveformsignalcolors.cpp
     src/waveform/renderers/waveformwidgetrenderer.cpp
-    src/waveform/sharedglcontext.cpp
     src/waveform/visualsmanager.cpp
     src/waveform/vsyncthread.cpp
     src/waveform/waveformmarklabel.cpp
@@ -1138,10 +1146,22 @@ else()
     src/widget/woverviewlmh.cpp
     src/widget/woverviewrgb.cpp
     src/widget/wspinny.cpp
-      src/widget/wvumetergl.cpp
+    src/widget/wvumetergl.cpp
     src/widget/wwaveformviewer.cpp
   )
+  if(QOPENGL)
+    target_sources(mixxx-lib PRIVATE
+      src/widget/openglwindow.cpp
+      src/widget/wglwidgetqopengl.cpp
+    )
+  else()
+    target_sources(mixxx-lib PRIVATE
+      src/waveform/sharedglcontext.cpp
+      src/widget/wglwidgetqglwidget.cpp
+    )
+  endif()
 endif()
+
 set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON CXX_CLANG_TIDY "${CLANG_TIDY}")
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
 if(UNIX AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1146,19 +1146,34 @@ else()
     src/widget/woverviewhsv.cpp
     src/widget/woverviewlmh.cpp
     src/widget/woverviewrgb.cpp
-    src/widget/wspinny.cpp
-    src/widget/wvumetergl.cpp
     src/widget/wwaveformviewer.cpp
   )
   if(QOPENGL)
     target_sources(mixxx-lib PRIVATE
       src/widget/openglwindow.cpp
       src/widget/wglwidgetqopengl.cpp
+      src/widget/qopengl/wvumetergl.cpp
+      src/widget/qopengl/wspinny.cpp
+      src/waveform/renderers/qopengl/waveformrenderbackground.cpp
+      src/waveform/renderers/qopengl/waveformrenderbeat.cpp
+      src/waveform/renderers/qopengl/waveformrenderer.cpp
+      src/waveform/renderers/qopengl/waveformrendererendoftrack.cpp
+      src/waveform/renderers/qopengl/waveformrendererpreroll.cpp
+      src/waveform/renderers/qopengl/waveformrendererrgb.cpp
+      src/waveform/renderers/qopengl/waveformrenderersignalbase.cpp
+      src/waveform/renderers/qopengl/waveformrendermark.cpp
+      src/waveform/renderers/qopengl/waveformrendermarkrange.cpp
+      src/waveform/widgets/qopengl/waveformwidget.cpp
+      src/waveform/widgets/qopengl/rgbwaveformwidget.cpp
+      src/waveform/widgets/qopengl/waveformwidget.cpp
+      src/waveform/widgets/qopengl/rgbwaveformwidget.cpp
     )
   else()
     target_sources(mixxx-lib PRIVATE
       src/waveform/sharedglcontext.cpp
       src/widget/wglwidgetqglwidget.cpp
+      src/widget/wvumetergl.cpp
+      src/widget/wspinny.cpp
     )
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1127,6 +1127,7 @@ else()
     src/waveform/waveformmarklabel.cpp
     src/waveform/waveformwidgetfactory.cpp
     src/waveform/widgets/emptywaveformwidget.cpp
+    src/waveform/widgets/glwaveformwidgetabstract.cpp
     src/waveform/widgets/glrgbwaveformwidget.cpp
     src/waveform/widgets/glsimplewaveformwidget.cpp
     src/waveform/widgets/glslwaveformwidget.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,6 +122,9 @@ int main(int argc, char * argv[]) {
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+#ifdef MIXXX_USE_QOPENGL
+    QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+#endif
 
     // workaround for https://bugreports.qt.io/browse/QTBUG-84363
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0) && QT_VERSION < QT_VERSION_CHECK(5, 15, 1)

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -2,7 +2,11 @@
 
 #include <QDesktopServices>
 #include <QFileDialog>
+
+#ifndef MIXXX_USE_QOPENGL
 #include <QGLFormat>
+#endif
+
 #include <QUrl>
 #include <QtDebug>
 
@@ -152,6 +156,7 @@ void MixxxMainWindow::initialize() {
                 }
             });
 
+#ifndef MIXXX_USE_QOPENGL
     // Before creating the first skin we need to create a QGLWidget so that all
     // the QGLWidget's we create can use it as a shared QGLContext.
     if (!CmdlineArgs::Instance().getSafeMode() && QGLFormat::hasOpenGL()) {
@@ -181,6 +186,7 @@ void MixxxMainWindow::initialize() {
         pContextWidget->hide();
         SharedGLContext::setWidget(pContextWidget);
     }
+#endif
 
     WaveformWidgetFactory::createInstance(); // takes a long time
     WaveformWidgetFactory::instance()->setConfig(m_pCoreServices->getSettings());

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1314,8 +1314,13 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     connect(waveformWidgetFactory,
             &WaveformWidgetFactory::renderSpinnies,
             pSpinny,
-            &WSpinny::render);
-    connect(waveformWidgetFactory, &WaveformWidgetFactory::swapSpinnies, pSpinny, &WSpinny::swap);
+            &WSpinny::render,
+            Qt::DirectConnection);
+    connect(waveformWidgetFactory,
+            &WaveformWidgetFactory::swapSpinnies,
+            pSpinny,
+            &WSpinny::swap,
+            Qt::DirectConnection);
     connect(pSpinny,
             &WSpinny::trackDropped,
             m_pPlayerManager,
@@ -1348,7 +1353,7 @@ QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
         return pVuMeterWidget;
     }
 
-    // QGLWidget derived WVuMeterGL
+    // WGLWidget derived WVuMeterGL
 
     if (CmdlineArgs::Instance().getSafeMode()) {
         WLabel* dummy = new WLabel(m_pParent);

--- a/src/util/widgetrendertimer.cpp
+++ b/src/util/widgetrendertimer.cpp
@@ -1,5 +1,7 @@
 #include "util/widgetrendertimer.h"
 
+#ifdef USE_WIDGET_RENDER_TIMER
+
 #include "moc_widgetrendertimer.cpp"
 #include "util/time.h"
 
@@ -28,3 +30,5 @@ void WidgetRenderTimer::activity() {
         m_guiTickTimer.start(m_renderFrequency);
     }
 }
+
+#endif

--- a/src/util/widgetrendertimer.h
+++ b/src/util/widgetrendertimer.h
@@ -26,6 +26,16 @@
 // Ironically, using this class somehow causes severe lagginess on mouse input
 // with Windows, so use #ifdefs to only call activity() on macOS; just call
 // QWidget::update() for other operating systems.
+//
+// Also when using the QOpenGLWindow based WGLWidget (when MIXXX_USE_QOPENGL is
+// defined) using this seems not necessary and makes causes lagginess
+#ifdef __APPLE__
+#ifndef MIXXX_USE_QOPENGL
+#define USE_WIDGET_RENDER_TIMER
+#endif
+#endif
+
+#ifdef USE_WIDGET_RENDER_TIMER
 class WidgetRenderTimer : public QObject {
     Q_OBJECT
   public:
@@ -53,3 +63,4 @@ class WidgetRenderTimer : public QObject {
     mixxx::Duration m_lastActivity;
     mixxx::Duration m_lastRender;
 };
+#endif

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -1,6 +1,11 @@
 #include "waveform/renderers/glslwaveformrenderersignal.h"
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 
+#ifdef MIXXX_USE_QOPENGL
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLShaderProgram>
+#else
+#endif
 #include <QGLFramebufferObject>
 #include <QGLShaderProgram>
 
@@ -49,14 +54,16 @@ bool GLSLWaveformRendererSignal::loadShaders() {
     m_frameShaderProgram->removeAllShaders();
 
     if (!m_frameShaderProgram->addShaderFromSourceFile(
-            QGLShader::Vertex, ":/shaders/passthrough.vert")) {
+                GL_SHADER_CLASS::Vertex,
+                ":/shaders/passthrough.vert")) {
         qDebug() << "GLWaveformRendererSignalShader::loadShaders - "
                  << m_frameShaderProgram->log();
         return false;
     }
 
     if (!m_frameShaderProgram->addShaderFromSourceFile(
-                QGLShader::Fragment, m_pFragShader)) {
+                GL_SHADER_CLASS::Fragment,
+                m_pFragShader)) {
         qDebug() << "GLWaveformRendererSignalShader::loadShaders - "
                  << m_frameShaderProgram->log();
         return false;
@@ -182,8 +189,8 @@ void GLSLWaveformRendererSignal::createFrameBuffers() {
             static_cast<int>(
                     m_waveformRenderer->getHeight() * devicePixelRatio);
 
-    m_framebuffer = std::make_unique<QGLFramebufferObject>(bufferWidth,
-                                                           bufferHeight);
+    m_framebuffer = std::make_unique<GL_FBO_CLASS>(bufferWidth,
+            bufferHeight);
 
     if (!m_framebuffer->isValid()) {
         qWarning() << "GLSLWaveformRendererSignal::createFrameBuffer - frame buffer not valid";
@@ -195,7 +202,7 @@ void GLSLWaveformRendererSignal::onInitializeGL() {
     m_textureRenderedWaveformCompletion = 0;
 
     if (!m_frameShaderProgram) {
-        m_frameShaderProgram = std::make_unique<QGLShaderProgram>();
+        m_frameShaderProgram = std::make_unique<GL_SHADER_PROGRAM_CLASS>();
     }
 
     if (!loadShaders()) {

--- a/src/waveform/renderers/glslwaveformrenderersignal.h
+++ b/src/waveform/renderers/glslwaveformrenderersignal.h
@@ -7,8 +7,18 @@
 #include "util/memory.h"
 #include "waveform/renderers/glwaveformrenderer.h"
 
-QT_FORWARD_DECLARE_CLASS(QGLFramebufferObject)
-QT_FORWARD_DECLARE_CLASS(QGLShaderProgram)
+#ifdef MIXXX_USE_QOPENGL
+#define GL_FBO_CLASS QOpenGLFramebufferObject
+#define GL_SHADER_CLASS QOpenGLShader
+#define GL_SHADER_PROGRAM_CLASS QOpenGLShaderProgram
+#else
+#define GL_FBO_CLASS QGLFramebufferObject
+#define GL_SHADER_CLASS QGLShader
+#define GL_SHADER_PROGRAM_CLASS QGLShaderProgram
+#endif
+
+QT_FORWARD_DECLARE_CLASS(GL_FBO_CLASS)
+QT_FORWARD_DECLARE_CLASS(GL_SHADER_PROGRAM_CLASS)
 
 class GLSLWaveformRendererSignal : public QObject,
                                    public GLWaveformRenderer {
@@ -50,7 +60,7 @@ class GLSLWaveformRendererSignal : public QObject,
     int m_textureRenderedWaveformCompletion;
 
     // Frame buffer for two pass rendering.
-    std::unique_ptr<QGLFramebufferObject> m_framebuffer;
+    std::unique_ptr<GL_FBO_CLASS> m_framebuffer;
 
     bool m_bDumpPng;
 
@@ -58,7 +68,7 @@ class GLSLWaveformRendererSignal : public QObject,
     bool m_shadersValid;
     ColorType m_colorType;
     const QString m_pFragShader;
-    std::unique_ptr<QGLShaderProgram> m_frameShaderProgram;
+    std::unique_ptr<GL_SHADER_PROGRAM_CLASS> m_frameShaderProgram;
 };
 
 class GLSLWaveformRendererFilteredSignal: public GLSLWaveformRendererSignal {

--- a/src/waveform/renderers/glwaveformrenderer.h
+++ b/src/waveform/renderers/glwaveformrenderer.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef MIXXX_USE_QOPENGL
 #include <QGLContext>
+#endif
 #include <QOpenGLFunctions_2_1>
 
 #include "waveform/renderers/waveformrenderersignalbase.h"
@@ -15,8 +17,12 @@
 class GLWaveformRenderer : public WaveformRendererSignalBase, protected QOpenGLFunctions_2_1 {
   public:
     GLWaveformRenderer(WaveformWidgetRenderer* waveformWidgetRenderer)
-            : WaveformRendererSignalBase(waveformWidgetRenderer),
-              m_pLastContext(nullptr) {
+            : WaveformRendererSignalBase(waveformWidgetRenderer)
+#ifndef MIXXX_USE_QOPENGL
+              ,
+              m_pLastContext(nullptr)
+#endif
+    {
     }
 
     virtual void onInitializeGL() {
@@ -28,14 +34,18 @@ class GLWaveformRenderer : public WaveformRendererSignalBase, protected QOpenGLF
     // by calling this in `draw` when the QGLContext has been made current.
     // TODO: remove this when upgrading to QOpenGLWidget
     void maybeInitializeGL() {
+#ifndef MIXXX_USE_QOPENGL
         if (QGLContext::currentContext() != m_pLastContext) {
             onInitializeGL();
             m_pLastContext = QGLContext::currentContext();
         }
+#endif
     }
 
   private:
+#ifndef MIXXX_USE_QOPENGL
     const QGLContext* m_pLastContext;
+#endif
 };
 
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)

--- a/src/waveform/renderers/qopengl/fixedpointcalc.h
+++ b/src/waveform/renderers/qopengl/fixedpointcalc.h
@@ -1,5 +1,7 @@
 /// functions to do fixed point calculations, used by qopengl::WaveformRendererRGB
 
+#include <cmath>
+
 // float to fixed point with 8 fractional bits, clipped at 4.0
 inline uint32_t toFrac8(float x) {
     return std::min<uint32_t>(static_cast<uint32_t>(std::max(x, 0.f) * 256.f), 4 * 256);

--- a/src/waveform/renderers/qopengl/fixedpointcalc.h
+++ b/src/waveform/renderers/qopengl/fixedpointcalc.h
@@ -1,0 +1,62 @@
+/// functions to do fixed point calculations, used by qopengl::WaveformRendererRGB
+
+// float to fixed point with 8 fractional bits, clipped at 4.0
+inline uint32_t toFrac8(float x) {
+    return std::min<uint32_t>(static_cast<uint32_t>(std::max(x, 0.f) * 256.f), 4 * 256);
+}
+
+// scaled sqrt lookable table to convert maxAll and maxAllNext as calculated
+// in updatePaintNode back to y coordinates
+class Frac16SqrtTableSingleton {
+  public:
+    static constexpr size_t frac16sqrtTableSize{(3 * 4 * 255 * 256) / 16 + 1};
+
+    static Frac16SqrtTableSingleton& getInstance() {
+        static Frac16SqrtTableSingleton instance;
+        return instance;
+    }
+
+    inline float get(uint32_t x) const {
+        // The maximum value of fact16x can be (as uint32_t) 3 * 4 * 255 * 256,
+        // which would be exessive for the table size. We divide by 16 in order
+        // to get a more reasonable size.
+        return m_table[x >> 4];
+    }
+
+  private:
+    float* m_table;
+    Frac16SqrtTableSingleton()
+            : m_table(new float[frac16sqrtTableSize]) {
+        // In the original implementation, the result of sqrt(maxAll) is divided
+        // by sqrt(3 * 255 * 255);
+        // We get rid of that division and bake it into this table.
+        // Additionally, we divide the index for the lookup by 16 (see get(...)),
+        // so we need to invert that here.
+        const float f = (3.f * 255.f * 255.f / 16.f);
+        for (uint32_t i = 0; i < frac16sqrtTableSize; i++) {
+            m_table[i] = std::sqrt(static_cast<float>(i) / f);
+        }
+    }
+    ~Frac16SqrtTableSingleton() {
+        delete[] m_table;
+    }
+    Frac16SqrtTableSingleton(const Frac16SqrtTableSingleton&) = delete;
+    Frac16SqrtTableSingleton& operator=(const Frac16SqrtTableSingleton&) = delete;
+};
+
+inline float frac16_sqrt(uint32_t x) {
+    return Frac16SqrtTableSingleton::getInstance().get(x);
+}
+
+inline uint32_t frac8Pow2ToFrac16(uint32_t x) {
+    // x is the result of multiplying two fixedpoint values with 8 fraction bits,
+    // thus x has 16 fraction bits, which is also what we want to return for this
+    // function. We would naively return (x * x) >> 16, but x * x would overflow
+    // the 32 bits for values > 1, so we shift before multiplying.
+    x >>= 8;
+    return (x * x);
+}
+
+inline uint32_t math_max_u32(uint32_t a, uint32_t b, uint32_t c) {
+    return std::max(a, std::max(b, c));
+}

--- a/src/waveform/renderers/qopengl/iwaveformrenderer.h
+++ b/src/waveform/renderers/qopengl/iwaveformrenderer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QOpenGLFunctions>
+
+/// Interface for QOpenGL-based waveform renderers
+
+namespace qopengl {
+class IWaveformRenderer;
+}
+
+class qopengl::IWaveformRenderer : public QOpenGLFunctions {
+  public:
+    virtual void initializeGL() {
+    }
+    virtual void resizeGL(int w, int h) {
+    }
+    virtual void renderGL() = 0;
+};

--- a/src/waveform/renderers/qopengl/waveformrenderbackground.cpp
+++ b/src/waveform/renderers/qopengl/waveformrenderbackground.cpp
@@ -1,0 +1,73 @@
+#include "waveform/renderers/qopengl/waveformrenderbackground.h"
+
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "widget/wimagestore.h"
+#include "widget/wskincolor.h"
+#include "widget/wwidget.h"
+
+using namespace qopengl;
+
+WaveformRenderBackground::WaveformRenderBackground(
+        WaveformWidgetRenderer* waveformWidgetRenderer)
+        : WaveformRenderer(waveformWidgetRenderer),
+          m_backgroundColor(0, 0, 0) {
+}
+
+WaveformRenderBackground::~WaveformRenderBackground() {
+}
+
+void WaveformRenderBackground::setup(const QDomNode& node,
+        const SkinContext& context) {
+    m_backgroundColor = m_waveformRenderer->getWaveformSignalColors()->getBgColor();
+    QString backgroundPixmapPath = context.selectString(node, "BgPixmap");
+    if (!backgroundPixmapPath.isEmpty()) {
+        m_backgroundPixmapPath = context.makeSkinPath(backgroundPixmapPath);
+    }
+    setDirty(true);
+}
+
+void WaveformRenderBackground::renderGL() {
+    if (isDirty()) {
+        // TODO @m0dB
+        //   generateImage();
+    }
+
+    // If there is no background image, just fill the painter with the
+    // background color.
+    if (m_backgroundImage.isNull()) {
+        glClearColor(m_backgroundColor.redF(),
+                m_backgroundColor.greenF(),
+                m_backgroundColor.blueF(),
+                1.f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        return;
+    }
+
+    //painter->drawImage(QPoint(0, 0), m_backgroundImage);
+}
+
+void WaveformRenderBackground::generateImage() {
+    m_backgroundImage = QImage();
+    if (!m_backgroundPixmapPath.isEmpty()) {
+        QImage backgroundImage = *WImageStore::getImage(
+                m_backgroundPixmapPath,
+                scaleFactor());
+
+        if (!backgroundImage.isNull()) {
+            if (backgroundImage.width() == m_waveformRenderer->getWidth() &&
+                    backgroundImage.height() == m_waveformRenderer->getHeight()) {
+                m_backgroundImage = backgroundImage.convertToFormat(QImage::Format_RGB32);
+            } else {
+                m_backgroundImage = QImage(m_waveformRenderer->getWidth(),
+                        m_waveformRenderer->getHeight(),
+                        QImage::Format_RGB32);
+                QPainter painter(&m_backgroundImage);
+                painter.setRenderHint(QPainter::SmoothPixmapTransform);
+                painter.drawImage(m_backgroundImage.rect(),
+                        backgroundImage,
+                        backgroundImage.rect());
+            }
+        }
+    }
+    setDirty(false);
+}

--- a/src/waveform/renderers/qopengl/waveformrenderbackground.h
+++ b/src/waveform/renderers/qopengl/waveformrenderbackground.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QColor>
+#include <QImage>
+
+#include "util/class.h"
+#include "waveform/renderers/qopengl/waveformrenderer.h"
+
+class QDomNode;
+class SkinContext;
+
+namespace qopengl {
+class WaveformRenderBackground;
+}
+class qopengl::WaveformRenderBackground : public qopengl::WaveformRenderer {
+  public:
+    explicit WaveformRenderBackground(WaveformWidgetRenderer* waveformWidgetRenderer);
+    ~WaveformRenderBackground() override;
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+    void renderGL() override;
+
+  private:
+    void generateImage();
+
+    QString m_backgroundPixmapPath;
+    QColor m_backgroundColor;
+    QImage m_backgroundImage;
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRenderBackground);
+};

--- a/src/waveform/renderers/qopengl/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/qopengl/waveformrenderbeat.cpp
@@ -1,0 +1,149 @@
+#include "waveform/renderers/qopengl/waveformrenderbeat.h"
+
+#include <QDomNode>
+
+#include "control/controlobject.h"
+#include "skin/legacy/skincontext.h"
+#include "track/track.h"
+#include "waveform/widgets/qopengl/waveformwidget.h"
+#include "widget/wskincolor.h"
+#include "widget/wwidget.h"
+
+using namespace qopengl;
+
+WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget)
+        : WaveformRenderer(waveformWidget) {
+    m_beatLineVertices.resize(1024);
+}
+
+WaveformRenderBeat::~WaveformRenderBeat() {
+}
+
+void WaveformRenderBeat::initializeGL() {
+    QString vertexShaderCode =
+            "\
+uniform mat4 matrix;\n\
+attribute vec4 position;\n\
+void main()\n\
+{\n\
+    gl_Position = matrix * position;\n\
+}\n";
+
+    QString fragmentShaderCode =
+            "\
+uniform vec4 color;\n\
+void main()\n\
+{\n\
+    gl_FragColor = color;\n\
+}\n";
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, fragmentShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.link()) {
+        return;
+    }
+
+    if (!m_shaderProgram.bind()) {
+        return;
+    }
+}
+
+void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& context) {
+    m_beatColor.setNamedColor(context.selectString(node, "BeatColor"));
+    m_beatColor = WSkinColor::getCorrectColor(m_beatColor).toRgb();
+}
+
+void WaveformRenderBeat::renderGL() {
+    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+
+    if (!trackInfo) {
+        return;
+    }
+
+    mixxx::BeatsPointer trackBeats = trackInfo->getBeats();
+    if (!trackBeats) {
+        return;
+    }
+
+    int alpha = m_waveformRenderer->getBeatGridAlpha();
+    if (alpha == 0) {
+        return;
+    }
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    m_beatColor.setAlphaF(alpha / 100.0);
+
+    const int trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
+        return;
+    }
+
+    const double firstDisplayedPosition =
+            m_waveformRenderer->getFirstDisplayedPosition();
+    const double lastDisplayedPosition =
+            m_waveformRenderer->getLastDisplayedPosition();
+
+    const auto startPosition = mixxx::audio::FramePos::fromEngineSamplePos(
+            firstDisplayedPosition * trackSamples);
+    const auto endPosition = mixxx::audio::FramePos::fromEngineSamplePos(
+            lastDisplayedPosition * trackSamples);
+    auto it = trackBeats->iteratorFrom(startPosition);
+
+    // TODO @m0dB use rendererWidth for vertical orientation
+    // and apply a 90 degrees rotation to the matrix
+    //const float rendererWidth = m_waveformRenderer->getWidth();
+    const float rendererHeight = m_waveformRenderer->getHeight();
+
+    int vertexCount = 0;
+
+    for (; it != trackBeats->cend() && *it <= endPosition; ++it) {
+        double beatPosition = it->toEngineSamplePos();
+        double xBeatPoint =
+                m_waveformRenderer->transformSamplePositionInRendererWorld(beatPosition);
+
+        xBeatPoint = qRound(xBeatPoint);
+
+        // If we don't have enough space, double the size.
+        if (vertexCount >= m_beatLineVertices.size()) {
+            m_beatLineVertices.resize(m_beatLineVertices.size() * 2);
+        }
+
+        m_beatLineVertices[vertexCount++] = xBeatPoint;
+        m_beatLineVertices[vertexCount++] = 0.f;
+        m_beatLineVertices[vertexCount++] = xBeatPoint + 1;
+        m_beatLineVertices[vertexCount++] = 0.f;
+        m_beatLineVertices[vertexCount++] = xBeatPoint;
+        m_beatLineVertices[vertexCount++] = rendererHeight;
+        m_beatLineVertices[vertexCount++] = xBeatPoint;
+        m_beatLineVertices[vertexCount++] = rendererHeight;
+        m_beatLineVertices[vertexCount++] = xBeatPoint + 1;
+        m_beatLineVertices[vertexCount++] = rendererHeight;
+        m_beatLineVertices[vertexCount++] = xBeatPoint + 1;
+        m_beatLineVertices[vertexCount++] = 0.f;
+    }
+    m_shaderProgram.bind();
+
+    int vertexLocation = m_shaderProgram.attributeLocation("position");
+    int matrixLocation = m_shaderProgram.uniformLocation("matrix");
+    int colorLocation = m_shaderProgram.uniformLocation("color");
+
+    QMatrix4x4 matrix;
+    matrix.ortho(QRectF(0, 0, m_waveformRenderer->getWidth(), m_waveformRenderer->getHeight()));
+
+    m_shaderProgram.enableAttributeArray(vertexLocation);
+    m_shaderProgram.setAttributeArray(
+            vertexLocation, GL_FLOAT, m_beatLineVertices.constData(), 2);
+
+    m_shaderProgram.setUniformValue(matrixLocation, matrix);
+    m_shaderProgram.setUniformValue(colorLocation, m_beatColor);
+
+    glDrawArrays(GL_TRIANGLES, 0, vertexCount / 2);
+}

--- a/src/waveform/renderers/qopengl/waveformrenderbeat.h
+++ b/src/waveform/renderers/qopengl/waveformrenderbeat.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QColor>
+#include <QOpenGLShaderProgram>
+
+#include "util/class.h"
+#include "waveform/renderers/qopengl/waveformrenderer.h"
+
+class QDomNode;
+class SkinContext;
+
+namespace qopengl {
+class WaveformRenderBeat;
+}
+
+class qopengl::WaveformRenderBeat : public qopengl::WaveformRenderer {
+  public:
+    explicit WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget);
+    ~WaveformRenderBeat() override;
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+    void renderGL() override;
+    void initializeGL() override;
+
+  private:
+    QColor m_beatColor;
+    QVector<float> m_beatLineVertices;
+    QOpenGLShaderProgram m_shaderProgram;
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRenderBeat);
+};

--- a/src/waveform/renderers/qopengl/waveformrenderer.cpp
+++ b/src/waveform/renderers/qopengl/waveformrenderer.cpp
@@ -1,0 +1,11 @@
+#include "waveform/renderers/qopengl/waveformrenderer.h"
+
+#include "waveform/widgets/qopengl/waveformwidget.h"
+
+using namespace qopengl;
+
+WaveformRenderer::WaveformRenderer(WaveformWidgetRenderer* widget)
+        : ::WaveformRendererAbstract(widget) {
+}
+
+WaveformRenderer::~WaveformRenderer() = default;

--- a/src/waveform/renderers/qopengl/waveformrenderer.h
+++ b/src/waveform/renderers/qopengl/waveformrenderer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QOpenGLFunctions>
+
+#include "waveform/renderers/qopengl/iwaveformrenderer.h"
+#include "waveform/renderers/waveformrendererabstract.h"
+
+class WaveformWidgetRenderer;
+
+namespace qopengl {
+class WaveformRenderer;
+} // namespace qopengl
+
+class qopengl::WaveformRenderer : public WaveformRendererAbstract, public IWaveformRenderer {
+  public:
+    explicit WaveformRenderer(WaveformWidgetRenderer* widget);
+    ~WaveformRenderer();
+
+    void draw(QPainter* painter, QPaintEvent* event) override {
+    }
+
+    IWaveformRenderer* qopenglWaveformRenderer() override {
+        return this;
+    }
+};

--- a/src/waveform/renderers/qopengl/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendererendoftrack.cpp
@@ -1,0 +1,134 @@
+#include "waveform/renderers/qopengl/waveformrendererendoftrack.h"
+
+#include <QDomNode>
+#include <QPaintEvent>
+#include <QPainter>
+
+#include "control/controlobject.h"
+#include "control/controlproxy.h"
+#include "util/timer.h"
+#include "waveform/waveformwidgetfactory.h"
+#include "waveform/widgets/qopengl/waveformwidget.h"
+#include "widget/wskincolor.h"
+#include "widget/wwidget.h"
+
+namespace {
+
+constexpr int kBlinkingPeriodMillis = 1000;
+
+} // anonymous namespace
+
+using namespace qopengl;
+
+WaveformRendererEndOfTrack::WaveformRendererEndOfTrack(
+        WaveformWidgetRenderer* waveformWidget)
+        : WaveformRenderer(waveformWidget),
+          m_pEndOfTrackControl(nullptr),
+          m_pTimeRemainingControl(nullptr) {
+}
+
+WaveformRendererEndOfTrack::~WaveformRendererEndOfTrack() {
+    delete m_pEndOfTrackControl;
+    delete m_pTimeRemainingControl;
+}
+
+bool WaveformRendererEndOfTrack::init() {
+    m_timer.restart();
+
+    m_pEndOfTrackControl = new ControlProxy(
+            m_waveformRenderer->getGroup(), "end_of_track");
+    m_pTimeRemainingControl = new ControlProxy(
+            m_waveformRenderer->getGroup(), "time_remaining");
+    return true;
+}
+
+void WaveformRendererEndOfTrack::setup(const QDomNode& node, const SkinContext& context) {
+    m_color = QColor(200, 25, 20);
+    const QString endOfTrackColorName = context.selectString(node, "EndOfTrackColor");
+    if (!endOfTrackColorName.isNull()) {
+        m_color.setNamedColor(endOfTrackColorName);
+        m_color = WSkinColor::getCorrectColor(m_color);
+    }
+    //m_pen = QPen(QBrush(m_color), 2.5 * scaleFactor());
+}
+
+void WaveformRendererEndOfTrack::initializeGL() {
+    QString vertexShaderCode =
+            "\
+uniform mat4 matrix;\n\
+attribute vec4 position;\n\
+varying vec2 vposition;\n\
+void main()\n\
+{\n\
+    vposition = position.xy;\n\
+    gl_Position = position;\n\
+}\n";
+
+    QString fragmentShaderCode =
+            "\
+uniform vec4 color;\n\
+varying vec2 vposition;\n\
+void main()\n\
+{\n\
+    gl_FragColor = vec4(color.x, color.y, color.z, color.w * (0.5 + 0.33 * max(0.,vposition.x)));\n\
+}\n";
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.addShaderFromSourceCode(
+                QOpenGLShader::Fragment, fragmentShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.link()) {
+        return;
+    }
+
+    if (!m_shaderProgram.bind()) {
+        return;
+    }
+}
+
+void WaveformRendererEndOfTrack::fillWithGradient(QColor color) {
+    const float posarray[] = {-1.f, -1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f};
+
+    m_shaderProgram.bind();
+
+    int colorLocation = m_shaderProgram.uniformLocation("color");
+    int positionLocation = m_shaderProgram.attributeLocation("position");
+
+    m_shaderProgram.setUniformValue(colorLocation, color);
+
+    m_shaderProgram.enableAttributeArray(positionLocation);
+    m_shaderProgram.setAttributeArray(
+            positionLocation, GL_FLOAT, posarray, 2);
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+void WaveformRendererEndOfTrack::renderGL() {
+    if (!m_pEndOfTrackControl->toBool()) {
+        return;
+    }
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
+
+    const double blinkIntensity = (double)(2 * abs(elapsed - kBlinkingPeriodMillis / 2)) /
+            kBlinkingPeriodMillis;
+
+    const double remainingTime = m_pTimeRemainingControl->get();
+    const double remainingTimeTriggerSeconds =
+            WaveformWidgetFactory::instance()->getEndOfTrackWarningTime();
+    const double criticalIntensity = (remainingTimeTriggerSeconds - remainingTime) /
+            remainingTimeTriggerSeconds;
+
+    QColor color = m_color;
+    color.setAlphaF(criticalIntensity * blinkIntensity);
+
+    fillWithGradient(color);
+}

--- a/src/waveform/renderers/qopengl/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/qopengl/waveformrendererendoftrack.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QColor>
+#include <QOpenGLShaderProgram>
+#include <QTime>
+
+#include "util/class.h"
+#include "util/performancetimer.h"
+#include "waveform/renderers/qopengl/waveformrenderer.h"
+
+class ControlObject;
+class ControlProxy;
+class QDomNode;
+class SkinContext;
+
+namespace qopengl {
+class WaveformRendererEndOfTrack;
+}
+
+class qopengl::WaveformRendererEndOfTrack : public qopengl::WaveformRenderer {
+  public:
+    explicit WaveformRendererEndOfTrack(
+            WaveformWidgetRenderer* waveformWidget);
+    ~WaveformRendererEndOfTrack() override;
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+    bool init() override;
+
+    void initializeGL() override;
+    void renderGL() override;
+
+  private:
+    void fillWithGradient(QColor color);
+
+    ControlProxy* m_pEndOfTrackControl;
+    ControlProxy* m_pTimeRemainingControl;
+    QOpenGLShaderProgram m_shaderProgram;
+
+    QColor m_color;
+    PerformanceTimer m_timer;
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRendererEndOfTrack);
+};

--- a/src/waveform/renderers/qopengl/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendererpreroll.cpp
@@ -1,0 +1,173 @@
+#include "waveform/renderers/qopengl/waveformrendererpreroll.h"
+
+#include <QDomNode>
+
+#include "skin/legacy/skincontext.h"
+#include "track/track.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "widget/wskincolor.h"
+#include "widget/wwidget.h"
+
+using namespace qopengl;
+
+WaveformRendererPreroll::WaveformRendererPreroll(WaveformWidgetRenderer* waveformWidget)
+        : WaveformRenderer(waveformWidget) {
+    m_vertices.resize(1024);
+}
+
+WaveformRendererPreroll::~WaveformRendererPreroll() {
+}
+
+void WaveformRendererPreroll::setup(
+        const QDomNode& node, const SkinContext& context) {
+    m_color.setNamedColor(context.selectString(node, "SignalColor"));
+    m_color = WSkinColor::getCorrectColor(m_color);
+}
+
+void WaveformRendererPreroll::initializeGL() {
+    QString vertexShaderCode =
+            "\
+uniform mat4 matrix;\n\
+attribute vec4 position;\n\
+void main()\n\
+{\n\
+    gl_Position = matrix * position;\n\
+}\n";
+
+    QString fragmentShaderCode =
+            "\
+uniform vec4 color;\n\
+void main()\n\
+{\n\
+    gl_FragColor = color;\n\
+}\n";
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, fragmentShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.link()) {
+        return;
+    }
+
+    if (!m_shaderProgram.bind()) {
+        return;
+    }
+}
+
+void WaveformRendererPreroll::renderGL() {
+    const TrackPointer track = m_waveformRenderer->getTrackInfo();
+    if (!track) {
+        return;
+    }
+
+    double firstDisplayedPosition = m_waveformRenderer->getFirstDisplayedPosition();
+    double lastDisplayedPosition = m_waveformRenderer->getLastDisplayedPosition();
+
+    // Check if the pre- or post-roll is on screen. If so, draw little triangles
+    // to indicate the respective zones.
+    bool preRollVisible = firstDisplayedPosition < 0;
+    bool postRollVisible = lastDisplayedPosition > 1;
+    int vertexCount = 0;
+    if (preRollVisible || postRollVisible) {
+        const double playMarkerPositionFrac = m_waveformRenderer->getPlayMarkerPosition();
+        const double vSamplesPerPixel = m_waveformRenderer->getVisualSamplePerPixel();
+        const double numberOfVSamples = m_waveformRenderer->getLength() * vSamplesPerPixel;
+
+        const int currentVSamplePosition = m_waveformRenderer->getPlayPosVSample();
+        const int totalVSamples = m_waveformRenderer->getTotalVSample();
+        // qDebug() << "currentVSamplePosition" << currentVSamplePosition
+        //          << "lastDisplayedPosition" << lastDisplayedPosition
+        //          << "vSamplesPerPixel" << vSamplesPerPixel
+        //          << "numberOfVSamples" << numberOfVSamples
+        //          << "totalVSamples" << totalVSamples
+        //          << "WaveformRendererPreroll::playMarkerPosition=" << playMarkerPositionFrac;
+
+        const float halfBreadth = m_waveformRenderer->getBreadth() / 2.0f;
+        const float halfPolyBreadth = m_waveformRenderer->getBreadth() / 5.0f;
+
+        /*
+        PainterScope PainterScope(painter);
+
+        painter->setRenderHint(QPainter::Antialiasing);
+        //painter->setRenderHint(QPainter::HighQualityAntialiasing);
+        //painter->setBackgroundMode(Qt::TransparentMode);
+        painter->setWorldMatrixEnabled(false);
+        painter->setPen(QPen(QBrush(m_color), std::max(1.0, scaleFactor())));
+        */
+
+        const double polyPixelWidth = 40.0 / vSamplesPerPixel;
+        const double polyPixelOffset = polyPixelWidth; // TODO @m0dB + painter->pen().widthF();
+        const double polyVSampleOffset = polyPixelOffset * vSamplesPerPixel;
+
+        // Rotate if drawing vertical waveforms
+        //if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
+        //    painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
+        //}
+
+        if (preRollVisible) {
+            // VSample position of the right-most triangle's tip
+            double triangleTipVSamplePosition =
+                    numberOfVSamples * playMarkerPositionFrac -
+                    currentVSamplePosition;
+
+            float x = triangleTipVSamplePosition / vSamplesPerPixel;
+
+            for (; triangleTipVSamplePosition > 0;
+                    triangleTipVSamplePosition -= polyVSampleOffset) {
+                m_vertices[vertexCount++] = x;
+                m_vertices[vertexCount++] = halfBreadth;
+                m_vertices[vertexCount++] = x - polyPixelWidth;
+                m_vertices[vertexCount++] = halfBreadth - halfPolyBreadth;
+                m_vertices[vertexCount++] = x - polyPixelWidth;
+                m_vertices[vertexCount++] = halfBreadth + halfPolyBreadth;
+
+                x -= polyPixelOffset;
+            }
+        }
+
+        if (postRollVisible) {
+            const int remainingVSamples = totalVSamples - currentVSamplePosition;
+            // Sample position of the left-most triangle's tip
+            double triangleTipVSamplePosition =
+                    playMarkerPositionFrac * numberOfVSamples +
+                    remainingVSamples;
+
+            float x = triangleTipVSamplePosition / vSamplesPerPixel;
+
+            for (; triangleTipVSamplePosition < numberOfVSamples;
+                    triangleTipVSamplePosition += polyVSampleOffset) {
+                m_vertices[vertexCount++] = x;
+                m_vertices[vertexCount++] = halfBreadth;
+                m_vertices[vertexCount++] = x + polyPixelWidth;
+                m_vertices[vertexCount++] = halfBreadth - halfPolyBreadth;
+                m_vertices[vertexCount++] = x + polyPixelWidth;
+                m_vertices[vertexCount++] = halfBreadth + halfPolyBreadth;
+
+                x += polyPixelOffset;
+            }
+        }
+    }
+
+    m_shaderProgram.bind();
+
+    int vertexLocation = m_shaderProgram.attributeLocation("position");
+    int matrixLocation = m_shaderProgram.uniformLocation("matrix");
+    int colorLocation = m_shaderProgram.uniformLocation("color");
+
+    QMatrix4x4 matrix;
+    matrix.ortho(QRectF(0, 0, m_waveformRenderer->getWidth(), m_waveformRenderer->getHeight()));
+
+    m_shaderProgram.enableAttributeArray(vertexLocation);
+    m_shaderProgram.setAttributeArray(
+            vertexLocation, GL_FLOAT, m_vertices.constData(), 2);
+
+    m_shaderProgram.setUniformValue(matrixLocation, matrix);
+    m_shaderProgram.setUniformValue(colorLocation, m_color);
+
+    glDrawArrays(GL_TRIANGLES, 0, vertexCount / 2);
+}

--- a/src/waveform/renderers/qopengl/waveformrendererpreroll.h
+++ b/src/waveform/renderers/qopengl/waveformrendererpreroll.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QColor>
+#include <QOpenGLShaderProgram>
+
+#include "util/class.h"
+#include "waveform/renderers/qopengl/waveformrenderer.h"
+
+class QDomNode;
+class SkinContext;
+
+namespace qopengl {
+class WaveformRendererPreroll;
+}
+
+class qopengl::WaveformRendererPreroll : public qopengl::WaveformRenderer {
+  public:
+    explicit WaveformRendererPreroll(WaveformWidgetRenderer* waveformWidgetRenderer);
+    ~WaveformRendererPreroll() override;
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+    void renderGL() override;
+    void initializeGL() override;
+
+  private:
+    QColor m_color;
+    QVector<float> m_vertices;
+    QOpenGLShaderProgram m_shaderProgram;
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRendererPreroll);
+};

--- a/src/waveform/renderers/qopengl/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendererrgb.cpp
@@ -1,0 +1,297 @@
+#include "waveform/renderers/qopengl/waveformrendererrgb.h"
+
+#include "fixedpointcalc.h"
+#include "track/track.h"
+#include "util/math.h"
+#include "waveform/waveform.h"
+#include "waveform/waveformwidgetfactory.h"
+#include "waveform/widgets/qopengl/waveformwidget.h"
+#include "widget/wskincolor.h"
+#include "widget/wwidget.h"
+
+using namespace qopengl;
+
+WaveformRendererRGB::WaveformRendererRGB(
+        WaveformWidgetRenderer* waveformWidget)
+        : WaveformRendererSignalBase(waveformWidget) {
+}
+
+WaveformRendererRGB::~WaveformRendererRGB() {
+}
+
+void WaveformRendererRGB::onSetup(const QDomNode& node) {
+    Q_UNUSED(node);
+}
+
+void WaveformRendererRGB::initializeGL() {
+    QString vertexShaderCode =
+            "\
+uniform mat4 matrix;\n\
+attribute vec4 position;\n\
+attribute vec3 color;\n\
+varying vec3 vcolor;\n\
+void main()\n\
+{\n\
+    vcolor = color;\n\
+    gl_Position = matrix * position;\n\
+}\n";
+
+    QString fragmentShaderCode =
+            "\
+varying vec3 vcolor;\n\
+void main()\n\
+{\n\
+    gl_FragColor = vec4(vcolor,1.0);\n\
+}\n";
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Fragment, fragmentShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.link()) {
+        return;
+    }
+
+    if (!m_shaderProgram.bind()) {
+        return;
+    }
+}
+
+inline void WaveformRendererRGB::addRectangle(
+        float x1,
+        float y1,
+        float x2,
+        float y2,
+        float r,
+        float g,
+        float b) {
+    m_lines[m_lineIndex++] = x1;
+    m_lines[m_lineIndex++] = y1;
+
+    m_lines[m_lineIndex++] = x2;
+    m_lines[m_lineIndex++] = y1;
+
+    m_lines[m_lineIndex++] = x1;
+    m_lines[m_lineIndex++] = y2;
+
+    m_lines[m_lineIndex++] = x1;
+    m_lines[m_lineIndex++] = y2;
+
+    m_lines[m_lineIndex++] = x2;
+    m_lines[m_lineIndex++] = y2;
+
+    m_lines[m_lineIndex++] = x2;
+    m_lines[m_lineIndex++] = y1;
+
+    for (int i = 0; i < 6; i++) {
+        m_colors[m_colorIndex++] = r;
+        m_colors[m_colorIndex++] = g;
+        m_colors[m_colorIndex++] = b;
+    }
+}
+
+void WaveformRendererRGB::renderGL() {
+    // The source of our data are uint8_t values (waveformData.filtered.low/mid/high).
+    // We can avoid type conversion by calculating the values needed for drawing
+    // using fixed point. Since the range of the intermediate values is limited, we
+    // can take advantage of this and use a lookup table instead of sqrtf.
+
+    uint32_t rgbLowColor_r = toFrac8(m_rgbLowColor_r);
+    uint32_t rgbMidColor_r = toFrac8(m_rgbMidColor_r);
+    uint32_t rgbHighColor_r = toFrac8(m_rgbHighColor_r);
+    uint32_t rgbLowColor_g = toFrac8(m_rgbLowColor_g);
+    uint32_t rgbMidColor_g = toFrac8(m_rgbMidColor_g);
+    uint32_t rgbHighColor_g = toFrac8(m_rgbHighColor_g);
+    uint32_t rgbLowColor_b = toFrac8(m_rgbLowColor_b);
+    uint32_t rgbMidColor_b = toFrac8(m_rgbMidColor_b);
+    uint32_t rgbHighColor_b = toFrac8(m_rgbHighColor_b);
+
+    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+    if (!pTrack) {
+        return;
+    }
+
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
+        return;
+    }
+
+    const int dataSize = waveform->getDataSize();
+    if (dataSize <= 1) {
+        return;
+    }
+
+    const WaveformData* data = waveform->data();
+    if (data == nullptr) {
+        return;
+    }
+
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+    const int n = static_cast<int>(static_cast<float>(
+            m_waveformRenderer->getLength() * devicePixelRatio));
+    // Not multiplying with devicePixelRatio will also work, and on retina displays 2 pixels will be used
+    // to represent each block of samples. This is also what is done for the beat grid and the markers.
+    // const int n = static_cast<int>(static_cast<float>(m_waveformRenderer->getLength()));
+
+    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
+    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
+
+    // Represents the # of waveform data points per horizontal pixel.
+    const double gain = (lastVisualIndex - firstVisualIndex) / static_cast<double>(n);
+
+    // Per-band gain from the EQ knobs.
+    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
+    getGains(&allGain, &lowGain, &midGain, &highGain);
+
+    // gains in 8 bit fractional fixed point
+    const uint32_t frac8LowGain(toFrac8(lowGain));
+    const uint32_t frac8MidGain(toFrac8(midGain));
+    const uint32_t frac8HighGain(toFrac8(highGain));
+
+    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
+    const float halfBreadth = breadth / 2.0f;
+
+    const float heightFactor = allGain * halfBreadth;
+
+    // Effective visual index of x
+    double xVisualSampleIndex = firstVisualIndex;
+
+    m_lineIndex = 0;
+    m_colorIndex = 0;
+
+    m_lines.resize(6 * 2 * (n + 1));
+    m_colors.resize(6 * 3 * (n + 1));
+
+    addRectangle(0.f,
+            halfBreadth - 0.5f,
+            static_cast<float>(n),
+            halfBreadth + 0.5f,
+            1.f,
+            1.f,
+            1.f);
+
+    for (int x = 0; x < n; ++x) {
+        // Our current pixel (x) corresponds to a number of visual samples
+        // (visualSamplerPerPixel) in our waveform object. We take the max of
+        // all the data points on either side of xVisualSampleIndex within a
+        // window of 'maxSamplingRange' visual samples to measure the maximum
+        // data point contained by this pixel.
+        double maxSamplingRange = gain / 2.0;
+
+        // Since xVisualSampleIndex is in visual-samples (e.g. R,L,R,L) we want
+        // to check +/- maxSamplingRange frames, not samples. To do this, divide
+        // xVisualSampleIndex by 2. Since frames indices are integers, we round
+        // to the nearest integer by adding 0.5 before casting to int.
+        int visualFrameStart = int(xVisualSampleIndex / 2.0 - maxSamplingRange + 0.5);
+        int visualFrameStop = int(xVisualSampleIndex / 2.0 + maxSamplingRange + 0.5);
+        const int lastVisualFrame = dataSize / 2 - 1;
+
+        // We now know that some subset of [visualFrameStart, visualFrameStop]
+        // lies within the valid range of visual frames. Clamp
+        // visualFrameStart/Stop to within [0, lastVisualFrame].
+        visualFrameStart = math_clamp(visualFrameStart, 0, lastVisualFrame);
+        visualFrameStop = math_clamp(visualFrameStop, 0, lastVisualFrame);
+
+        int visualIndexStart = visualFrameStart * 2;
+        int visualIndexStop = visualFrameStop * 2;
+
+        visualIndexStart = std::max(visualIndexStart, 0);
+        visualIndexStop = std::min(visualIndexStop, dataSize);
+
+        uint32_t maxLow = 0;
+        uint32_t maxMid = 0;
+        uint32_t maxHigh = 0;
+
+        uint32_t maxAll = 0.;
+        uint32_t maxAllNext = 0.;
+
+        for (int i = visualIndexStart; i < visualIndexStop; i += 2) {
+            const WaveformData& waveformData = data[i];
+            const WaveformData& waveformDataNext = data[i + 1];
+
+            maxLow = math_max_u32(maxLow, waveformData.filtered.low, waveformDataNext.filtered.low);
+            maxMid = math_max_u32(maxMid, waveformData.filtered.mid, waveformDataNext.filtered.mid);
+            maxHigh = math_max_u32(maxHigh,
+                    waveformData.filtered.high,
+                    waveformDataNext.filtered.high);
+
+            uint32_t all = frac8Pow2ToFrac16(waveformData.filtered.low * frac8LowGain) +
+                    frac8Pow2ToFrac16(waveformData.filtered.mid * frac8MidGain) +
+                    frac8Pow2ToFrac16(waveformData.filtered.high * frac8HighGain);
+            maxAll = math_max(maxAll, all);
+
+            uint32_t allNext = frac8Pow2ToFrac16(waveformDataNext.filtered.low * frac8LowGain) +
+                    frac8Pow2ToFrac16(waveformDataNext.filtered.mid * frac8MidGain) +
+                    frac8Pow2ToFrac16(waveformDataNext.filtered.high * frac8HighGain);
+            maxAllNext = math_max(maxAllNext, allNext);
+        }
+
+        // We can do these integer calculation safely, staying well within the
+        // 32 bit range, and we will normalize below.
+        maxLow *= frac8LowGain;
+        maxMid *= frac8MidGain;
+        maxHigh *= frac8HighGain;
+        uint32_t red = maxLow * rgbLowColor_r + maxMid * rgbMidColor_r +
+                maxHigh * rgbHighColor_r;
+        uint32_t green = maxLow * rgbLowColor_g + maxMid * rgbMidColor_g +
+                maxHigh * rgbHighColor_g;
+        uint32_t blue = maxLow * rgbLowColor_b + maxMid * rgbMidColor_b +
+                maxHigh * rgbHighColor_b;
+
+        // Normalize red, green, blue to 0..255, using the maximum of the three and
+        // this fixed point arithmetic trick:
+        // max / ((max>>8)+1) = 0..255
+        uint32_t max = math_max_u32(red, green, blue);
+        max >>= 8;
+
+        if (max == 0) {
+            // avoid division by 0
+            red = 0;
+            green = 0;
+            blue = 0;
+        } else {
+            max++; // important, otherwise we normalize to 256
+
+            red /= max;
+            green /= max;
+            blue /= max;
+        }
+
+        const float fx = static_cast<float>(x);
+
+        // lines are thin rectangles
+        addRectangle(fx,
+                halfBreadth - heightFactor * frac16_sqrt(maxAll),
+                fx + 1.f,
+                halfBreadth + heightFactor * frac16_sqrt(maxAllNext),
+                float(red) / 255.f,
+                float(green) / 255.f,
+                float(blue) / 255.f);
+
+        xVisualSampleIndex += gain;
+    }
+
+    QMatrix4x4 matrix;
+    matrix.ortho(QRectF(0, 0, n, m_waveformRenderer->getHeight()));
+
+    m_shaderProgram.bind();
+
+    int matrixLocation = m_shaderProgram.uniformLocation("matrix");
+    int positionLocation = m_shaderProgram.attributeLocation("position");
+    int colorLocation = m_shaderProgram.attributeLocation("color");
+
+    m_shaderProgram.setUniformValue(matrixLocation, matrix);
+
+    m_shaderProgram.enableAttributeArray(positionLocation);
+    m_shaderProgram.setAttributeArray(
+            positionLocation, GL_FLOAT, m_lines.constData(), 2);
+    m_shaderProgram.enableAttributeArray(colorLocation);
+    m_shaderProgram.setAttributeArray(
+            colorLocation, GL_FLOAT, m_colors.constData(), 3);
+
+    glDrawArrays(GL_TRIANGLES, 0, m_lineIndex / 2);
+}

--- a/src/waveform/renderers/qopengl/waveformrendererrgb.h
+++ b/src/waveform/renderers/qopengl/waveformrendererrgb.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QOpenGLShaderProgram>
+
+#include "waveform/renderers/qopengl/waveformrenderersignalbase.h"
+
+namespace qopengl {
+class WaveformRendererRGB;
+}
+
+class qopengl::WaveformRendererRGB : public qopengl::WaveformRendererSignalBase {
+  public:
+    explicit WaveformRendererRGB(WaveformWidgetRenderer* waveformWidget);
+    ~WaveformRendererRGB() override;
+
+    // override ::WaveformRendererSignalBase
+    void onSetup(const QDomNode& node) override;
+
+    void initializeGL() override;
+    void renderGL() override;
+
+  private:
+    int m_lineIndex;
+    int m_colorIndex;
+
+    QVector<float> m_lines;
+    QVector<float> m_colors;
+
+    QOpenGLShaderProgram m_shaderProgram;
+
+    void addRectangle(float x1, float y1, float x2, float y2, float r, float g, float b);
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRendererRGB);
+};

--- a/src/waveform/renderers/qopengl/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/qopengl/waveformrenderersignalbase.cpp
@@ -1,0 +1,10 @@
+#include "waveform/renderers/qopengl/waveformrenderersignalbase.h"
+
+#include "waveform/widgets/qopengl/waveformwidget.h"
+
+using namespace qopengl;
+
+qopengl::WaveformRendererSignalBase::WaveformRendererSignalBase(
+        WaveformWidgetRenderer* waveformWidget)
+        : ::WaveformRendererSignalBase(waveformWidget) {
+}

--- a/src/waveform/renderers/qopengl/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/qopengl/waveformrenderersignalbase.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "waveform/renderers/qopengl/iwaveformrenderer.h"
+#include "waveform/renderers/waveformrenderersignalbase.h"
+
+class WaveformWidgetRenderer;
+
+namespace qopengl {
+class WaveformRendererSignalBase;
+} // namespace qopengl
+
+class qopengl::WaveformRendererSignalBase : public ::WaveformRendererSignalBase,
+                                            public qopengl::IWaveformRenderer {
+  public:
+    explicit WaveformRendererSignalBase(WaveformWidgetRenderer* waveformWidget);
+    ~WaveformRendererSignalBase() override = default;
+
+    void draw(QPainter* painter, QPaintEvent* event) override {
+    }
+
+    IWaveformRenderer* qopenglWaveformRenderer() override {
+        return this;
+    }
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRendererSignalBase);
+};

--- a/src/waveform/renderers/qopengl/waveformrendermark.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendermark.cpp
@@ -2,6 +2,7 @@
 
 #include <QDomNode>
 #include <QOpenGLTexture>
+#include <QPainterPath>
 
 #include "control/controlobject.h"
 #include "engine/controls/cuecontrol.h"

--- a/src/waveform/renderers/qopengl/waveformrendermark.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendermark.cpp
@@ -1,0 +1,696 @@
+#include "waveform/renderers/qopengl/waveformrendermark.h"
+
+#include <QDomNode>
+#include <QOpenGLTexture>
+
+#include "control/controlobject.h"
+#include "engine/controls/cuecontrol.h"
+#include "track/track.h"
+#include "util/color/color.h"
+#include "util/painterscope.h"
+#include "waveform/renderers/qopengl/moc_waveformrendermark.cpp"
+#include "waveform/waveform.h"
+#include "waveform/widgets/qopengl/waveformwidget.h"
+#include "widget/wimagestore.h"
+#include "widget/wskincolor.h"
+
+namespace {
+constexpr int kMaxCueLabelLength = 23;
+} // namespace
+
+using namespace qopengl;
+
+WaveformRenderMark::WaveformRenderMark(WaveformWidgetRenderer* waveformWidget)
+        : WaveformRenderer(waveformWidget) {
+}
+
+WaveformRenderMark::~WaveformRenderMark() {
+    for (const auto& pMark : m_marks) {
+        pMark->m_pTexture.reset();
+    }
+}
+
+void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
+    WaveformSignalColors signalColors = *m_waveformRenderer->getWaveformSignalColors();
+    m_marks.setup(m_waveformRenderer->getGroup(), node, context, signalColors);
+}
+
+void WaveformRenderMark::initializeGL() {
+    initGradientShader();
+    initTextureShader();
+
+    generatePlayPosMarkTexture();
+}
+
+void WaveformRenderMark::initGradientShader() {
+    QString vertexShaderCode =
+            "\
+uniform mat4 matrix;\n\
+attribute vec4 position;\n\
+attribute vec3 gradient;\n\
+varying vec3 vGradient;\n\
+void main()\n\
+{\n\
+    vGradient = gradient;\n\
+    gl_Position = matrix * position;\n\
+}\n";
+
+    QString fragmentShaderCode =
+            "\
+uniform vec4 color;\n\
+varying vec3 vGradient;\n\
+void main()\n\
+{\n\
+    gl_FragColor = vec4(color.x, color.y, color.z, color.w * max(0.0, abs((vGradient.x + vGradient.y) * 4.0 - 2.0) - 1.0));\n\
+}\n";
+
+    if (!m_gradientShaderProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderCode)) {
+        return;
+    }
+
+    if (!m_gradientShaderProgram.addShaderFromSourceCode(
+                QOpenGLShader::Fragment, fragmentShaderCode)) {
+        return;
+    }
+
+    if (!m_gradientShaderProgram.link()) {
+        return;
+    }
+
+    if (!m_gradientShaderProgram.bind()) {
+        return;
+    }
+}
+
+void WaveformRenderMark::initTextureShader() {
+    QString vertexShaderCode =
+            "\
+uniform mat4 matrix;\n\
+attribute vec4 position;\n\
+attribute vec3 texcoor;\n\
+varying vec3 vTexcoor;\n\
+void main()\n\
+{\n\
+    vTexcoor = texcoor;\n\
+    gl_Position = matrix * position;\n\
+}\n";
+
+    QString fragmentShaderCode =
+            "\
+uniform sampler2D sampler;\n\
+varying vec3 vTexcoor;\n\
+void main()\n\
+{\n\
+    gl_FragColor = texture2D(sampler, vec2(vTexcoor.x, vTexcoor.y));\n\
+}\n";
+
+    if (!m_textureShaderProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderCode)) {
+        return;
+    }
+
+    if (!m_textureShaderProgram.addShaderFromSourceCode(
+                QOpenGLShader::Fragment, fragmentShaderCode)) {
+        return;
+    }
+
+    if (!m_textureShaderProgram.link()) {
+        return;
+    }
+
+    if (!m_textureShaderProgram.bind()) {
+        return;
+    }
+}
+
+void WaveformRenderMark::drawTexture(int x, int y, QOpenGLTexture* texture) {
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+    const float texx1 = 0.f;
+    const float texy1 = 0.f;
+    const float texx2 = 1.f;
+    const float texy2 = 1.f;
+
+    const float posx1 = x;
+    const float posx2 = x + texture->width() / devicePixelRatio;
+    const float posy1 = y;
+    const float posy2 = y + texture->height() / devicePixelRatio;
+
+    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
+    const float texarray[] = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
+
+    QMatrix4x4 matrix;
+    matrix.ortho(QRectF(0, 0, m_waveformRenderer->getWidth(), m_waveformRenderer->getHeight()));
+
+    m_textureShaderProgram.bind();
+
+    int matrixLocation = m_textureShaderProgram.uniformLocation("matrix");
+    int samplerLocation = m_textureShaderProgram.uniformLocation("sampler");
+    int positionLocation = m_textureShaderProgram.attributeLocation("position");
+    int texcoordLocation = m_textureShaderProgram.attributeLocation("texcoor");
+
+    m_textureShaderProgram.setUniformValue(matrixLocation, matrix);
+
+    m_textureShaderProgram.enableAttributeArray(positionLocation);
+    m_textureShaderProgram.setAttributeArray(
+            positionLocation, GL_FLOAT, posarray, 2);
+    m_textureShaderProgram.enableAttributeArray(texcoordLocation);
+    m_textureShaderProgram.setAttributeArray(
+            texcoordLocation, GL_FLOAT, texarray, 2);
+
+    m_textureShaderProgram.setUniformValue(samplerLocation, 0);
+
+    texture->bind();
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+void WaveformRenderMark::fillRectWithGradient(
+        const QRectF& rect, QColor color, Qt::Orientation orientation) {
+    const float grdx1 = 0.f;
+    const float grdy1 = 0.f;
+    const float grdx2 = orientation == Qt::Horizontal ? 1.f : 0.f;
+    const float grdy2 = orientation == Qt::Vertical ? 1.f : 0.f;
+
+    const float posx1 = rect.x();
+    const float posx2 = rect.x() + rect.width();
+    const float posy1 = rect.y();
+    const float posy2 = rect.y() + rect.height();
+
+    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
+    const float grdarray[] = {grdx1, grdy1, grdx2, grdy1, grdx1, grdy2, grdx2, grdy2};
+
+    QMatrix4x4 matrix;
+    matrix.ortho(QRectF(0, 0, m_waveformRenderer->getWidth(), m_waveformRenderer->getHeight()));
+    m_gradientShaderProgram.bind();
+
+    int matrixLocation = m_gradientShaderProgram.uniformLocation("matrix");
+    int colorLocation = m_gradientShaderProgram.uniformLocation("color");
+    int positionLocation = m_gradientShaderProgram.attributeLocation("position");
+    int gradientLocation = m_gradientShaderProgram.attributeLocation("gradient");
+
+    m_gradientShaderProgram.setUniformValue(matrixLocation, matrix);
+    m_gradientShaderProgram.setUniformValue(colorLocation, color);
+
+    m_gradientShaderProgram.enableAttributeArray(positionLocation);
+    m_gradientShaderProgram.setAttributeArray(
+            positionLocation, GL_FLOAT, posarray, 2);
+    m_gradientShaderProgram.enableAttributeArray(gradientLocation);
+    m_gradientShaderProgram.setAttributeArray(
+            gradientLocation, GL_FLOAT, grdarray, 2);
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+void WaveformRenderMark::renderGL() {
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+    QMap<WaveformMarkPointer, int> marksOnScreen;
+
+    checkCuesUpdated();
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    for (const auto& pMark : m_marks) {
+        if (!pMark->isValid()) {
+            continue;
+        }
+
+        if (pMark->hasVisible() && !pMark->isVisible()) {
+            continue;
+        }
+
+        // Generate image on first paint can't be done in setup since we need to
+        // wait for the render widget to be resized yet.
+        if (pMark->m_image.isNull()) {
+            generateMarkImage(pMark);
+        }
+
+        const double samplePosition = pMark->getSamplePosition();
+        if (samplePosition != Cue::kNoPosition) {
+            double currentMarkPoint =
+                    m_waveformRenderer->transformSamplePositionInRendererWorld(samplePosition);
+            const double sampleEndPosition = pMark->getSampleEndPosition();
+
+            currentMarkPoint = qRound(currentMarkPoint);
+
+            if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+                // Pixmaps are expected to have the mark stroke at the center,
+                // and preferably have an odd width in order to have the stroke
+                // exactly at the sample position.
+                const int markHalfWidth = static_cast<int>(
+                        pMark->m_image.width() / 2.0 / devicePixelRatio);
+                const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfWidth;
+
+                bool visible = false;
+                // Check if the current point needs to be displayed.
+                if (currentMarkPoint > -markHalfWidth &&
+                        currentMarkPoint < m_waveformRenderer->getWidth() +
+                                        markHalfWidth) {
+                    drawTexture(drawOffset, 0, pMark->m_pTexture.get());
+                    visible = true;
+                }
+
+                // Check if the range needs to be displayed.
+                if (samplePosition != sampleEndPosition && sampleEndPosition != Cue::kNoPosition) {
+                    DEBUG_ASSERT(samplePosition < sampleEndPosition);
+                    double currentMarkEndPoint =
+                            m_waveformRenderer->transformSamplePositionInRendererWorld(
+                                    sampleEndPosition);
+
+                    currentMarkEndPoint = qRound(currentMarkEndPoint);
+
+                    if (visible || currentMarkEndPoint > 0) {
+                        QColor color = pMark->fillColor();
+                        color.setAlphaF(0.4);
+
+                        fillRectWithGradient(
+                                QRectF(QPointF(currentMarkPoint, 0),
+                                        QPointF(currentMarkEndPoint,
+                                                m_waveformRenderer
+                                                        ->getHeight())),
+                                color,
+                                Qt::Vertical);
+                        visible = true;
+                    }
+                }
+
+                if (visible) {
+                    marksOnScreen[pMark] = drawOffset;
+                }
+            } else {
+                const int markHalfHeight = static_cast<int>(pMark->m_image.height() / 2.0);
+                const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfHeight;
+
+                bool visible = false;
+                // Check if the current point needs to be displayed.
+                if (currentMarkPoint > -markHalfHeight &&
+                        currentMarkPoint < m_waveformRenderer->getHeight() +
+                                        markHalfHeight) {
+                    drawTexture(drawOffset, 0, pMark->m_pTexture.get());
+                    visible = true;
+                }
+
+                // Check if the range needs to be displayed.
+                if (samplePosition != sampleEndPosition && sampleEndPosition != Cue::kNoPosition) {
+                    DEBUG_ASSERT(samplePosition < sampleEndPosition);
+                    double currentMarkEndPoint =
+                            m_waveformRenderer
+                                    ->transformSamplePositionInRendererWorld(
+                                            sampleEndPosition);
+                    if (currentMarkEndPoint < m_waveformRenderer->getHeight()) {
+                        QColor color = pMark->fillColor();
+                        color.setAlphaF(0.4);
+                        fillRectWithGradient(
+                                QRectF(QPointF(0, currentMarkPoint),
+                                        QPointF(m_waveformRenderer->getWidth(),
+                                                currentMarkEndPoint)),
+                                color,
+                                Qt::Horizontal);
+                        visible = true;
+                    }
+                }
+
+                if (visible) {
+                    marksOnScreen[pMark] = drawOffset;
+                }
+            }
+        }
+    }
+    m_waveformRenderer->setMarkPositions(marksOnScreen);
+
+    double currentMarkPoint =
+            qRound(m_waveformRenderer->getPlayMarkerPosition() *
+                    m_waveformRenderer->getWidth());
+    const int markHalfWidth = static_cast<int>(
+            m_pPlayPosMarkTexture->width() / 2.0 / devicePixelRatio);
+    const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfWidth;
+
+    drawTexture(drawOffset, 0, m_pPlayPosMarkTexture.get());
+}
+
+void WaveformRenderMark::generatePlayPosMarkTexture() {
+    float imgwidth;
+    float imgheight;
+
+    const auto width = m_waveformRenderer->getWidth();
+    const auto height = m_waveformRenderer->getHeight();
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+
+    //    const auto playMarkerPosition = m_waveformRenderer->getPlayMarkerPosition();
+    const auto orientation = m_waveformRenderer->getOrientation();
+
+    const int lineX = 5;
+    const int lineY = 5;
+
+    if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+        imgwidth = 11;
+        imgheight = m_waveformRenderer->getHeight();
+    } else {
+        imgwidth = m_waveformRenderer->getWidth();
+        imgheight = 11;
+    }
+
+    QImage image(static_cast<int>(imgwidth * devicePixelRatio),
+            static_cast<int>(imgheight * devicePixelRatio),
+            QImage::Format_ARGB32_Premultiplied);
+    image.setDevicePixelRatio(devicePixelRatio);
+    image.fill(QColor(0, 0, 0, 0).rgba());
+
+    QPainter painter;
+
+    painter.begin(&image);
+
+    painter.setWorldMatrixEnabled(false);
+
+    // draw dim outlines to increase playpos/waveform contrast
+    painter.setOpacity(0.5);
+    painter.setPen(m_waveformRenderer->getWaveformSignalColors()->getBgColor());
+    QBrush bgFill = m_waveformRenderer->getWaveformSignalColors()->getBgColor();
+    if (orientation == Qt::Horizontal) {
+        // lines next to playpos
+        // Note: don't draw lines where they would overlap the triangles,
+        // otherwise both translucent strokes add up to a darker tone.
+        painter.drawLine(lineX + 1, 4, lineX + 1, height);
+        painter.drawLine(lineX - 1, 4, lineX - 1, height);
+
+        // triangle at top edge
+        // Increase line/waveform contrast
+        painter.setOpacity(0.8);
+        QPointF t0 = QPointF(lineX - 5, 0);
+        QPointF t1 = QPointF(lineX + 5, 0);
+        QPointF t2 = QPointF(lineX, 6);
+        drawTriangle(&painter, bgFill, t0, t1, t2);
+    } else { // vertical waveforms
+        painter.drawLine(4, lineY + 1, width, lineY + 1);
+        painter.drawLine(4, lineY - 1, width, lineY - 1);
+        // triangle at left edge
+        painter.setOpacity(0.8);
+        QPointF l0 = QPointF(0, lineY - 5.01);
+        QPointF l1 = QPointF(0, lineY + 4.99);
+        QPointF l2 = QPointF(6, lineY);
+        drawTriangle(&painter, bgFill, l0, l1, l2);
+    }
+
+    // draw colored play position indicators
+    painter.setOpacity(1.0);
+    painter.setPen(m_waveformRenderer->getWaveformSignalColors()->getPlayPosColor());
+    QBrush fgFill = m_waveformRenderer->getWaveformSignalColors()->getPlayPosColor();
+    if (orientation == Qt::Horizontal) {
+        // play position line
+        painter.drawLine(lineX, 0, lineX, height);
+        // triangle at top edge
+        QPointF t0 = QPointF(lineX - 4, 0);
+        QPointF t1 = QPointF(lineX + 4, 0);
+        QPointF t2 = QPointF(lineX, 5);
+        drawTriangle(&painter, fgFill, t0, t1, t2);
+    } else {
+        // vertical waveforms
+        painter.drawLine(0, lineY, width, lineY);
+        // triangle at left edge
+        QPointF l0 = QPointF(0, lineY - 4.01);
+        QPointF l1 = QPointF(0, lineY + 4);
+        QPointF l2 = QPointF(5, lineY);
+        drawTriangle(&painter, fgFill, l0, l1, l2);
+    }
+    painter.end();
+
+    m_pPlayPosMarkTexture.reset(new QOpenGLTexture(image));
+    m_pPlayPosMarkTexture->setMinificationFilter(QOpenGLTexture::Linear);
+    m_pPlayPosMarkTexture->setMagnificationFilter(QOpenGLTexture::Linear);
+    m_pPlayPosMarkTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
+}
+
+void WaveformRenderMark::drawTriangle(QPainter* painter,
+        const QBrush& fillColor,
+        QPointF p0,
+        QPointF p1,
+        QPointF p2) {
+    QPainterPath triangle;
+    painter->setPen(Qt::NoPen);
+    triangle.moveTo(p0); // ° base 1
+    triangle.lineTo(p1); // > base 2
+    triangle.lineTo(p2); // > peak
+    triangle.lineTo(p0); // > base 1
+    painter->fillPath(triangle, fillColor);
+}
+
+void WaveformRenderMark::resizeGL(int, int) {
+    // Delete all marks' images. New images will be created on next paint.
+    for (const auto& pMark : m_marks) {
+        pMark->m_image = QImage();
+    }
+}
+
+void WaveformRenderMark::onSetTrack() {
+    slotCuesUpdated();
+
+    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+    if (!trackInfo) {
+        return;
+    }
+    connect(trackInfo.get(),
+            &Track::cuesUpdated,
+            this,
+            &WaveformRenderMark::slotCuesUpdated);
+}
+
+void WaveformRenderMark::slotCuesUpdated() {
+    m_bCuesUpdates = true;
+}
+
+void WaveformRenderMark::checkCuesUpdated() {
+    if (!m_bCuesUpdates) {
+        return;
+    }
+    // TODO @m0dB use atomic?
+    m_bCuesUpdates = false;
+
+    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+    if (!trackInfo) {
+        return;
+    }
+
+    QList<CuePointer> loadedCues = trackInfo->getCuePoints();
+    for (const CuePointer& pCue : loadedCues) {
+        int hotCue = pCue->getHotCue();
+        if (hotCue == Cue::kNoHotCue) {
+            continue;
+        }
+
+        // Here we assume no two cues can have the same hotcue assigned,
+        // because WaveformMarkSet stores one mark for each hotcue.
+        WaveformMarkPointer pMark = m_marks.getHotCueMark(hotCue);
+        if (pMark.isNull()) {
+            continue;
+        }
+
+        QString newLabel = pCue->getLabel();
+        QColor newColor = mixxx::RgbColor::toQColor(pCue->getColor());
+        if (pMark->m_text.isNull() || newLabel != pMark->m_text ||
+                !pMark->fillColor().isValid() ||
+                newColor != pMark->fillColor()) {
+            pMark->m_text = newLabel;
+            int dimBrightThreshold = m_waveformRenderer->getDimBrightThreshold();
+            pMark->setBaseColor(newColor, dimBrightThreshold);
+            generateMarkImage(pMark);
+        }
+    }
+}
+
+void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
+    // Load the pixmap from file.
+    // If that succeeds loading the text and stroke is skipped.
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+    if (!pMark->m_pixmapPath.isEmpty()) {
+        QString path = pMark->m_pixmapPath;
+        // Use devicePixelRatio to properly scale the image
+        QImage image = *WImageStore::getImage(path, devicePixelRatio);
+        //QImage image = QImage(path);
+        // If loading the image didn't fail, then we're done. Otherwise fall
+        // through and render a label.
+        if (!image.isNull()) {
+            pMark->m_image =
+                    image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+            //WImageStore::correctImageColors(&pMark->m_image);
+            // Set the pixel/device ratio AFTER loading the image in order to get
+            // a truly scaled source image.
+            // See https://doc.qt.io/qt-5/qimage.html#setDevicePixelRatio
+            // Also, without this some Qt-internal issue results in an offset
+            // image when calculating the center line of pixmaps in draw().
+            pMark->m_image.setDevicePixelRatio(devicePixelRatio);
+            pMark->m_pTexture.reset(new QOpenGLTexture(pMark->m_image));
+            pMark->m_pTexture->setMinificationFilter(QOpenGLTexture::Linear);
+            pMark->m_pTexture->setMagnificationFilter(QOpenGLTexture::Linear);
+            pMark->m_pTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
+            return;
+        }
+    }
+
+    {
+        QPainter painter;
+
+        // Determine mark text.
+        QString label = pMark->m_text;
+        if (pMark->getHotCue() >= 0) {
+            if (!label.isEmpty()) {
+                label.prepend(": ");
+            }
+            label.prepend(QString::number(pMark->getHotCue() + 1));
+            if (label.size() > kMaxCueLabelLength) {
+                label = label.left(kMaxCueLabelLength - 3) + "...";
+            }
+        }
+
+        // This alone would pick the OS default font, or that set by Qt5 Settings (qt5ct)
+        // respectively. This would mostly not be notable since contemporary OS and distros
+        // use a proven sans-serif anyway. Though, some user fonts may be lacking glyphs
+        // we use for the intro/outro markers for example.
+        QFont font;
+        // So, let's just use Open Sans which is used by all official skins to achieve
+        // a consistent skin design.
+        font.setFamily("Open Sans");
+        // Use a pixel size like everywhere else in Mixxx, which can be scaled well
+        // in general.
+        // Point sizes would work if only explicit Qt scaling QT_SCALE_FACTORS is used,
+        // though as soon as other OS-based font and app scaling mechanics join the
+        // party the resulting font size is hard to predict (affects all supported OS).
+        font.setPixelSize(13);
+        font.setWeight(75); // bold
+        font.setItalic(false);
+
+        QFontMetrics metrics(font);
+
+        //fixed margin ...
+        QRect wordRect = metrics.tightBoundingRect(label);
+        constexpr int marginX = 1;
+        constexpr int marginY = 1;
+        wordRect.moveTop(marginX + 1);
+        wordRect.moveLeft(marginY + 1);
+        wordRect.setHeight(wordRect.height() + (wordRect.height() % 2));
+        wordRect.setWidth(wordRect.width() + (wordRect.width()) % 2);
+        //even wordrect to have an even Image >> draw the line in the middle !
+
+        int labelRectWidth = wordRect.width() + 2 * marginX + 4;
+        int labelRectHeight = wordRect.height() + 2 * marginY + 4;
+
+        QRectF labelRect(0, 0, (float)labelRectWidth, (float)labelRectHeight);
+
+        int width;
+        int height;
+
+        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+            width = 2 * labelRectWidth + 1;
+            height = m_waveformRenderer->getHeight();
+        } else {
+            width = m_waveformRenderer->getWidth();
+            height = 2 * labelRectHeight + 1;
+        }
+
+        pMark->m_image = QImage(
+                static_cast<int>(width * devicePixelRatio),
+                static_cast<int>(height * devicePixelRatio),
+                QImage::Format_ARGB32_Premultiplied);
+        pMark->m_image.setDevicePixelRatio(devicePixelRatio);
+
+        Qt::Alignment markAlignH = pMark->m_align & Qt::AlignHorizontal_Mask;
+        Qt::Alignment markAlignV = pMark->m_align & Qt::AlignVertical_Mask;
+
+        if (markAlignH == Qt::AlignHCenter) {
+            labelRect.moveLeft((width - labelRectWidth) / 2);
+        } else if (markAlignH == Qt::AlignRight) {
+            labelRect.moveRight(width - 1);
+        }
+
+        if (markAlignV == Qt::AlignVCenter) {
+            labelRect.moveTop((height - labelRectHeight) / 2);
+        } else if (markAlignV == Qt::AlignBottom) {
+            labelRect.moveBottom(height - 1);
+        }
+
+        pMark->m_label.setAreaRect(labelRect);
+
+        // Fill with transparent pixels
+        pMark->m_image.fill(QColor(0, 0, 0, 0).rgba());
+
+        painter.begin(&pMark->m_image);
+        painter.setRenderHint(QPainter::TextAntialiasing);
+
+        painter.setWorldMatrixEnabled(false);
+
+        // Draw marker lines
+        if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+            int middle = width / 2;
+            pMark->m_linePosition = middle;
+            if (markAlignH == Qt::AlignHCenter) {
+                if (labelRect.top() > 0) {
+                    painter.setPen(pMark->fillColor());
+                    painter.drawLine(QLineF(middle, 0, middle, labelRect.top()));
+
+                    painter.setPen(pMark->borderColor());
+                    painter.drawLine(QLineF(middle - 1, 0, middle - 1, labelRect.top()));
+                    painter.drawLine(QLineF(middle + 1, 0, middle + 1, labelRect.top()));
+                }
+
+                if (labelRect.bottom() < height) {
+                    painter.setPen(pMark->fillColor());
+                    painter.drawLine(QLineF(middle, labelRect.bottom(), middle, height));
+
+                    painter.setPen(pMark->borderColor());
+                    painter.drawLine(QLineF(middle - 1, labelRect.bottom(), middle - 1, height));
+                    painter.drawLine(QLineF(middle + 1, labelRect.bottom(), middle + 1, height));
+                }
+            } else { // AlignLeft || AlignRight
+                painter.setPen(pMark->fillColor());
+                painter.drawLine(middle, 0, middle, height);
+
+                painter.setPen(pMark->borderColor());
+                painter.drawLine(middle - 1, 0, middle - 1, height);
+                painter.drawLine(middle + 1, 0, middle + 1, height);
+            }
+        } else { // Vertical
+            int middle = height / 2;
+            pMark->m_linePosition = middle;
+            if (markAlignV == Qt::AlignVCenter) {
+                if (labelRect.left() > 0) {
+                    painter.setPen(pMark->fillColor());
+                    painter.drawLine(QLineF(0, middle, labelRect.left(), middle));
+
+                    painter.setPen(pMark->borderColor());
+                    painter.drawLine(QLineF(0, middle - 1, labelRect.left(), middle - 1));
+                    painter.drawLine(QLineF(0, middle + 1, labelRect.left(), middle + 1));
+                }
+
+                if (labelRect.right() < width) {
+                    painter.setPen(pMark->fillColor());
+                    painter.drawLine(QLineF(labelRect.right(), middle, width, middle));
+
+                    painter.setPen(pMark->borderColor());
+                    painter.drawLine(QLineF(labelRect.right(), middle - 1, width, middle - 1));
+                    painter.drawLine(QLineF(labelRect.right(), middle + 1, width, middle + 1));
+                }
+            } else { // AlignTop || AlignBottom
+                painter.setPen(pMark->fillColor());
+                painter.drawLine(0, middle, width, middle);
+
+                painter.setPen(pMark->borderColor());
+                painter.drawLine(0, middle - 1, width, middle - 1);
+                painter.drawLine(0, middle + 1, width, middle + 1);
+            }
+        }
+
+        // Draw the label rect
+        painter.setPen(pMark->borderColor());
+        painter.setBrush(QBrush(pMark->fillColor()));
+        painter.drawRoundedRect(labelRect, 2.0, 2.0);
+
+        // Draw text
+        painter.setBrush(QBrush(QColor(0, 0, 0, 0)));
+        painter.setFont(font);
+        painter.setPen(pMark->labelColor());
+        painter.drawText(labelRect, Qt::AlignCenter, label);
+    }
+
+    pMark->m_pTexture.reset(new QOpenGLTexture(pMark->m_image));
+    pMark->m_pTexture->setMinificationFilter(QOpenGLTexture::Linear);
+    pMark->m_pTexture->setMagnificationFilter(QOpenGLTexture::Linear);
+    pMark->m_pTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
+}

--- a/src/waveform/renderers/qopengl/waveformrendermark.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendermark.cpp
@@ -18,31 +18,29 @@ namespace {
 constexpr int kMaxCueLabelLength = 23;
 } // namespace
 
-using namespace qopengl;
-
-WaveformRenderMark::WaveformRenderMark(WaveformWidgetRenderer* waveformWidget)
+qopengl::WaveformRenderMark::WaveformRenderMark(WaveformWidgetRenderer* waveformWidget)
         : WaveformRenderer(waveformWidget) {
 }
 
-WaveformRenderMark::~WaveformRenderMark() {
+qopengl::WaveformRenderMark::~WaveformRenderMark() {
     for (const auto& pMark : m_marks) {
         pMark->m_pTexture.reset();
     }
 }
 
-void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
+void qopengl::WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
     WaveformSignalColors signalColors = *m_waveformRenderer->getWaveformSignalColors();
     m_marks.setup(m_waveformRenderer->getGroup(), node, context, signalColors);
 }
 
-void WaveformRenderMark::initializeGL() {
+void qopengl::WaveformRenderMark::initializeGL() {
     initGradientShader();
     initTextureShader();
 
     generatePlayPosMarkTexture();
 }
 
-void WaveformRenderMark::initGradientShader() {
+void qopengl::WaveformRenderMark::initGradientShader() {
     QString vertexShaderCode =
             "\
 uniform mat4 matrix;\n\
@@ -82,7 +80,7 @@ void main()\n\
     }
 }
 
-void WaveformRenderMark::initTextureShader() {
+void qopengl::WaveformRenderMark::initTextureShader() {
     QString vertexShaderCode =
             "\
 uniform mat4 matrix;\n\
@@ -122,7 +120,7 @@ void main()\n\
     }
 }
 
-void WaveformRenderMark::drawTexture(int x, int y, QOpenGLTexture* texture) {
+void qopengl::WaveformRenderMark::drawTexture(int x, int y, QOpenGLTexture* texture) {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const float texx1 = 0.f;
     const float texy1 = 0.f;
@@ -163,7 +161,7 @@ void WaveformRenderMark::drawTexture(int x, int y, QOpenGLTexture* texture) {
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
 
-void WaveformRenderMark::fillRectWithGradient(
+void qopengl::WaveformRenderMark::fillRectWithGradient(
         const QRectF& rect, QColor color, Qt::Orientation orientation) {
     const float grdx1 = 0.f;
     const float grdy1 = 0.f;
@@ -200,7 +198,7 @@ void WaveformRenderMark::fillRectWithGradient(
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
 
-void WaveformRenderMark::renderGL() {
+void qopengl::WaveformRenderMark::renderGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     QMap<WaveformMarkPointer, int> marksOnScreen;
 
@@ -327,7 +325,7 @@ void WaveformRenderMark::renderGL() {
     drawTexture(drawOffset, 0, m_pPlayPosMarkTexture.get());
 }
 
-void WaveformRenderMark::generatePlayPosMarkTexture() {
+void qopengl::WaveformRenderMark::generatePlayPosMarkTexture() {
     float imgwidth;
     float imgheight;
 
@@ -419,7 +417,7 @@ void WaveformRenderMark::generatePlayPosMarkTexture() {
     m_pPlayPosMarkTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
 }
 
-void WaveformRenderMark::drawTriangle(QPainter* painter,
+void qopengl::WaveformRenderMark::drawTriangle(QPainter* painter,
         const QBrush& fillColor,
         QPointF p0,
         QPointF p1,
@@ -433,14 +431,14 @@ void WaveformRenderMark::drawTriangle(QPainter* painter,
     painter->fillPath(triangle, fillColor);
 }
 
-void WaveformRenderMark::resizeGL(int, int) {
+void qopengl::WaveformRenderMark::resizeGL(int, int) {
     // Delete all marks' images. New images will be created on next paint.
     for (const auto& pMark : m_marks) {
         pMark->m_image = QImage();
     }
 }
 
-void WaveformRenderMark::onSetTrack() {
+void qopengl::WaveformRenderMark::onSetTrack() {
     slotCuesUpdated();
 
     TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
@@ -450,14 +448,14 @@ void WaveformRenderMark::onSetTrack() {
     connect(trackInfo.get(),
             &Track::cuesUpdated,
             this,
-            &WaveformRenderMark::slotCuesUpdated);
+            &qopengl::WaveformRenderMark::slotCuesUpdated);
 }
 
-void WaveformRenderMark::slotCuesUpdated() {
+void qopengl::WaveformRenderMark::slotCuesUpdated() {
     m_bCuesUpdates = true;
 }
 
-void WaveformRenderMark::checkCuesUpdated() {
+void qopengl::WaveformRenderMark::checkCuesUpdated() {
     if (!m_bCuesUpdates) {
         return;
     }
@@ -496,7 +494,7 @@ void WaveformRenderMark::checkCuesUpdated() {
     }
 }
 
-void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
+void qopengl::WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
     // Load the pixmap from file.
     // If that succeeds loading the text and stroke is skipped.
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();

--- a/src/waveform/renderers/qopengl/waveformrendermark.h
+++ b/src/waveform/renderers/qopengl/waveformrendermark.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QColor>
+#include <QObject>
+#include <QOpenGLShaderProgram>
+
+#include "util/class.h"
+#include "waveform/renderers/qopengl/waveformrenderer.h"
+#include "waveform/renderers/waveformmarkset.h"
+
+class QDomNode;
+class SkinContext;
+class QOpenGLTexture;
+
+namespace qopengl {
+class WaveformRenderMark;
+}
+
+class qopengl::WaveformRenderMark : public QObject, public qopengl::WaveformRenderer {
+    Q_OBJECT
+  public:
+    explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidget);
+    ~WaveformRenderMark() override;
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+    void initializeGL() override;
+    void renderGL() override;
+    void resizeGL(int w, int h) override;
+
+    // Called when a new track is loaded.
+    void onSetTrack() override;
+
+  public slots:
+    // Called when the loaded track's cues are added, deleted or modified and
+    // when a new track is loaded.
+    // It updates the marks' names and regenerates their image if needed.
+    // This method is used for hotcues.
+    void slotCuesUpdated();
+
+  private:
+    void checkCuesUpdated();
+
+    void initGradientShader();
+    void initTextureShader();
+
+    void generateMarkImage(WaveformMarkPointer pMark);
+    void generatePlayPosMarkTexture();
+
+    void drawTriangle(QPainter* painter,
+            const QBrush& fillColor,
+            QPointF p1,
+            QPointF p2,
+            QPointF p3);
+
+    WaveformMarkSet m_marks;
+    QOpenGLShaderProgram m_gradientShaderProgram;
+    QOpenGLShaderProgram m_textureShaderProgram;
+    std::unique_ptr<QOpenGLTexture> m_pPlayPosMarkTexture;
+    bool m_bCuesUpdates{};
+
+    void fillRectWithGradient(const QRectF& rect, QColor color, Qt::Orientation orientation);
+    void drawTexture(int x, int y, QOpenGLTexture* texture);
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
+};

--- a/src/waveform/renderers/qopengl/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendermarkrange.cpp
@@ -1,0 +1,147 @@
+#include "waveform/renderers/qopengl/waveformrendermarkrange.h"
+
+#include <QColor>
+#include <QDomNode>
+#include <QObject>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QVector>
+
+#include "preferences/usersettings.h"
+#include "track/track.h"
+#include "util/painterscope.h"
+#include "waveform/widgets/qopengl/waveformwidget.h"
+#include "widget/wskincolor.h"
+#include "widget/wwidget.h"
+
+using namespace qopengl;
+
+WaveformRenderMarkRange::WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidget)
+        : WaveformRenderer(waveformWidget) {
+}
+
+WaveformRenderMarkRange::~WaveformRenderMarkRange() {
+}
+
+void WaveformRenderMarkRange::initializeGL() {
+    QString vertexShaderCode =
+            "\
+uniform mat4 matrix;\n\
+attribute vec4 position;\n\
+void main()\n\
+{\n\
+    gl_Position = matrix * position;\n\
+}\n";
+
+    QString fragmentShaderCode =
+            "\
+uniform vec4 color;\n\
+void main()\n\
+{\n\
+    gl_FragColor = color;\n\
+}\n";
+
+    if (!m_shaderProgram.addShaderFromSourceCode(QOpenGLShader::Vertex, vertexShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.addShaderFromSourceCode(
+                QOpenGLShader::Fragment, fragmentShaderCode)) {
+        return;
+    }
+
+    if (!m_shaderProgram.link()) {
+        return;
+    }
+
+    if (!m_shaderProgram.bind()) {
+        return;
+    }
+}
+void WaveformRenderMarkRange::fillRect(
+        const QRectF& rect, QColor color) {
+    const float posx1 = rect.x();
+    const float posx2 = rect.x() + rect.width();
+    const float posy1 = rect.y();
+    const float posy2 = rect.y() + rect.height();
+
+    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
+
+    int colorLocation = m_shaderProgram.uniformLocation("color");
+    int positionLocation = m_shaderProgram.attributeLocation("position");
+
+    m_shaderProgram.setUniformValue(colorLocation, color);
+
+    m_shaderProgram.enableAttributeArray(positionLocation);
+    m_shaderProgram.setAttributeArray(
+            positionLocation, GL_FLOAT, posarray, 2);
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+void WaveformRenderMarkRange::setup(const QDomNode& node, const SkinContext& context) {
+    m_markRanges.clear();
+    m_markRanges.reserve(1);
+
+    QDomNode child = node.firstChild();
+    while (!child.isNull()) {
+        if (child.nodeName() == "MarkRange") {
+            m_markRanges.push_back(
+                    WaveformMarkRange(
+                            m_waveformRenderer->getGroup(),
+                            child,
+                            context,
+                            *m_waveformRenderer->getWaveformSignalColors()));
+        }
+        child = child.nextSibling();
+    }
+}
+
+void WaveformRenderMarkRange::renderGL() {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    QMatrix4x4 matrix;
+    matrix.ortho(QRectF(0, 0, m_waveformRenderer->getWidth(), m_waveformRenderer->getHeight()));
+    m_shaderProgram.bind();
+
+    int matrixLocation = m_shaderProgram.uniformLocation("matrix");
+    m_shaderProgram.setUniformValue(matrixLocation, matrix);
+
+    for (auto&& markRange : m_markRanges) {
+        // If the mark range is not active we should not draw it.
+        if (!markRange.active()) {
+            continue;
+        }
+
+        // If the mark range is not visible we should not draw it.
+        if (!markRange.visible()) {
+            continue;
+        }
+
+        // Active mark ranges by definition have starts/ends that are not
+        // disabled so no need to check.
+        double startSample = markRange.start();
+        double endSample = markRange.end();
+
+        double startPosition =
+                m_waveformRenderer->transformSamplePositionInRendererWorld(
+                        startSample);
+        double endPosition = m_waveformRenderer->transformSamplePositionInRendererWorld(endSample);
+
+        startPosition = qRound(startPosition);
+        endPosition = qRound(endPosition);
+
+        const double span = std::max(endPosition - startPosition, 1.0);
+
+        //range not in the current display
+        if (startPosition > m_waveformRenderer->getLength() || endPosition < 0) {
+            continue;
+        }
+
+        QColor color = markRange.enabled() ? markRange.m_activeColor : markRange.m_disabledColor;
+        color.setAlphaF(0.3);
+
+        fillRect(QRectF(startPosition, 0, span, m_waveformRenderer->getHeight()), color);
+    }
+}

--- a/src/waveform/renderers/qopengl/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/qopengl/waveformrendermarkrange.cpp
@@ -14,16 +14,14 @@
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
 
-using namespace qopengl;
-
-WaveformRenderMarkRange::WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidget)
+qopengl::WaveformRenderMarkRange::WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidget)
         : WaveformRenderer(waveformWidget) {
 }
 
-WaveformRenderMarkRange::~WaveformRenderMarkRange() {
+qopengl::WaveformRenderMarkRange::~WaveformRenderMarkRange() {
 }
 
-void WaveformRenderMarkRange::initializeGL() {
+void qopengl::WaveformRenderMarkRange::initializeGL() {
     QString vertexShaderCode =
             "\
 uniform mat4 matrix;\n\
@@ -58,7 +56,7 @@ void main()\n\
         return;
     }
 }
-void WaveformRenderMarkRange::fillRect(
+void qopengl::WaveformRenderMarkRange::fillRect(
         const QRectF& rect, QColor color) {
     const float posx1 = rect.x();
     const float posx2 = rect.x() + rect.width();
@@ -79,7 +77,7 @@ void WaveformRenderMarkRange::fillRect(
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
 
-void WaveformRenderMarkRange::setup(const QDomNode& node, const SkinContext& context) {
+void qopengl::WaveformRenderMarkRange::setup(const QDomNode& node, const SkinContext& context) {
     m_markRanges.clear();
     m_markRanges.reserve(1);
 
@@ -97,7 +95,7 @@ void WaveformRenderMarkRange::setup(const QDomNode& node, const SkinContext& con
     }
 }
 
-void WaveformRenderMarkRange::renderGL() {
+void qopengl::WaveformRenderMarkRange::renderGL() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 

--- a/src/waveform/renderers/qopengl/waveformrendermarkrange.h
+++ b/src/waveform/renderers/qopengl/waveformrendermarkrange.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QColor>
+#include <QOpenGLShaderProgram>
+#include <vector>
+
+#include "preferences/usersettings.h"
+#include "waveform/renderers/qopengl/waveformrenderer.h"
+#include "waveform/renderers/waveformmarkrange.h"
+
+class QDomNode;
+class SkinContext;
+
+namespace qopengl {
+class WaveformRenderMarkRange;
+}
+
+class qopengl::WaveformRenderMarkRange : public qopengl::WaveformRenderer {
+  public:
+    explicit WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidget);
+    ~WaveformRenderMarkRange() override;
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+    void initializeGL() override;
+    void renderGL() override;
+
+  private:
+    void fillRect(const QRectF& rect, QColor color);
+
+    QOpenGLShaderProgram m_shaderProgram;
+    std::vector<WaveformMarkRange> m_markRanges;
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRenderMarkRange);
+};

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -1,10 +1,13 @@
+#include "waveformmark.h"
+
+#ifdef MIXXX_USE_QOPENGL
+#include <QOpenGLTexture>
+#endif
 #include <QtDebug>
 
 #include "skin/legacy/skincontext.h"
 #include "waveform/renderers/waveformsignalcolors.h"
 #include "widget/wskincolor.h"
-
-#include "waveformmark.h"
 
 namespace {
 Qt::Alignment decodeAlignmentFlags(const QString& alignString, Qt::Alignment defaultFlags) {
@@ -109,6 +112,8 @@ WaveformMark::WaveformMark(const QString& group,
         m_pixmapPath = context.makeSkinPath(m_pixmapPath);
     }
 }
+
+WaveformMark::~WaveformMark() = default;
 
 void WaveformMark::setBaseColor(QColor baseColor, int dimBrightThreshold) {
     m_image = QImage();

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -14,6 +14,13 @@ class WaveformSignalColors;
 
 class WOverview;
 
+#ifdef MIXXX_USE_QOPENGL
+class QOpenGLTexture;
+namespace qopengl {
+class WaveformRenderMark;
+}
+#endif
+
 class WaveformMark {
   public:
     WaveformMark(
@@ -22,6 +29,7 @@ class WaveformMark {
             const SkinContext& context,
             const WaveformSignalColors& signalColors,
             int hotCue = Cue::kNoHotCue);
+    ~WaveformMark();
 
     // Disable copying
     WaveformMark(const WaveformMark&) = delete;
@@ -101,6 +109,10 @@ class WaveformMark {
     std::unique_ptr<ControlProxy> m_pPositionCO;
     std::unique_ptr<ControlProxy> m_pEndPositionCO;
     std::unique_ptr<ControlProxy> m_pVisibleCO;
+#ifdef MIXXX_USE_QOPENGL
+    std::unique_ptr<QOpenGLTexture> m_pTexture; // used by qopengl::WaveformRenderMark
+    friend class qopengl::WaveformRenderMark;
+#endif
     int m_iHotCue;
     QImage m_image;
 

--- a/src/waveform/renderers/waveformmarkrange.h
+++ b/src/waveform/renderers/waveformmarkrange.h
@@ -13,6 +13,12 @@ QT_FORWARD_DECLARE_CLASS(QDomNode);
 class SkinContext;
 class WaveformSignalColors;
 
+#ifdef MIXXX_USE_QOPENGL
+namespace qopengl {
+class WaveformRenderMarkRange;
+}
+#endif
+
 class WaveformMarkRange {
   public:
     WaveformMarkRange(
@@ -71,5 +77,8 @@ class WaveformMarkRange {
     DurationTextLocation m_durationTextLocation;
 
     friend class WaveformRenderMarkRange;
+#ifdef MIXXX_USE_QOPENGL
+    friend class qopengl::WaveformRenderMarkRange;
+#endif
     friend class WOverview;
 };

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -40,7 +40,12 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     if (alpha == 0) {
         return;
     }
+#ifdef MIXXX_USE_QOPENGL
+    // TODO @m0dB using alpha transparency for the beat lines causes has artifacts with QOpenGL.
+    m_beatColor.setAlphaF(1.f);
+#else
     m_beatColor.setAlphaF(alpha/100.0);
+#endif
 
     const int trackSamples = m_waveformRenderer->getTrackSamples();
     if (trackSamples <= 0) {

--- a/src/waveform/renderers/waveformrendererabstract.h
+++ b/src/waveform/renderers/waveformrendererabstract.h
@@ -9,6 +9,12 @@ QT_FORWARD_DECLARE_CLASS(QPainter)
 class SkinContext;
 class WaveformWidgetRenderer;
 
+#ifdef MIXXX_USE_QOPENGL
+namespace qopengl {
+class IWaveformRenderer;
+}
+#endif
+
 class WaveformRendererAbstract {
   public:
     explicit WaveformRendererAbstract(
@@ -21,6 +27,12 @@ class WaveformRendererAbstract {
 
     virtual void onResize() {}
     virtual void onSetTrack() {}
+
+#ifdef MIXXX_USE_QOPENGL
+    virtual qopengl::IWaveformRenderer* qopenglWaveformRenderer() {
+        return nullptr;
+    }
+#endif
 
   protected:
     bool isDirty() const {

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -191,7 +191,7 @@ void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
     // not ready to display need to wait until track initialization is done
     // draw only first in stack (background)
     int stackSize = m_rendererStack.size();
-    if (m_trackSamples <= 0.0 || m_playPos == -1) {
+    if (shouldOnlyDrawBackground()) {
         if (stackSize) {
             m_rendererStack.at(0)->draw(painter, event);
         }

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -157,6 +157,10 @@ class WaveformWidgetRenderer {
 
     void setPassThroughEnabled(bool enabled);
 
+    bool shouldOnlyDrawBackground() const {
+        return m_trackSamples <= 0.0 || m_playPos == -1;
+    }
+
   protected:
     const QString m_group;
     TrackPointer m_pTrack;

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -1,6 +1,5 @@
 #include "vsyncthread.h"
 
-#include <QGLFormat>
 #include <QThread>
 #include <QTime>
 #include <QtDebug>

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <QTime>
-#include <QThread>
-#include <QSemaphore>
 #include <QPair>
-#include <QGLWidget>
+#include <QSemaphore>
+#include <QThread>
+#include <QTime>
 
 #include "util/performancetimer.h"
+#include "widget/wglwidget.h"
 
 class VSyncThread : public QThread {
     Q_OBJECT
@@ -25,7 +25,7 @@ class VSyncThread : public QThread {
 
     void run();
 
-    bool waitForVideoSync(QGLWidget* glw);
+    bool waitForVideoSync(WGLWidget* glw);
     int elapsed();
     int toNextSyncMicros();
     void setSyncIntervalTimeMicros(int usSyncTimer);
@@ -35,8 +35,8 @@ class VSyncThread : public QThread {
     int fromTimerToNextSyncMicros(const PerformanceTimer& timer);
     void vsyncSlotFinished();
     void getAvailableVSyncTypes(QList<QPair<int, QString>>* list);
-    void setupSync(QGLWidget* glw, int index);
-    void waitUntilSwap(QGLWidget* glw);
+    void setupSync(WGLWidget* glw, int index);
+    void waitUntilSwap(WGLWidget* glw);
     mixxx::Duration sinceLastSwap() const;
   signals:
     void vsyncRender();

--- a/src/waveform/widgets/glrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/glrgbwaveformwidget.cpp
@@ -14,9 +14,9 @@
 
 GLRGBWaveformWidget::GLRGBWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -27,11 +27,6 @@ GLRGBWaveformWidget::GLRGBWaveformWidget(const QString& group, QWidget* parent)
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -55,7 +50,7 @@ mixxx::Duration GLRGBWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -17,9 +17,9 @@
 
 GLSimpleWaveformWidget::GLSimpleWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -30,11 +30,6 @@ GLSimpleWaveformWidget::GLSimpleWaveformWidget(const QString& group, QWidget* pa
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -57,7 +52,7 @@ mixxx::Duration GLSimpleWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -17,9 +17,9 @@
 
 GLVSyncTestWidget::GLVSyncTestWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>(); // 172 µs
 //  addRenderer<WaveformRendererEndOfTrack>(); // 677 µs 1145 µs (active)
@@ -33,13 +33,7 @@ GLVSyncTestWidget::GLVSyncTestWidget(const QString& group, QWidget* parent)
     // addRenderer<WaveformRenderMark>(); // 711 µs
     // addRenderer<WaveformRenderBeat>(); // 1183 µs
 
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
-
     m_initSuccess = init();
-    qDebug() << "GLVSyncTestWidget.isSharing() =" << isSharing();
 }
 
 GLVSyncTestWidget::~GLVSyncTestWidget() {
@@ -60,7 +54,7 @@ mixxx::Duration GLVSyncTestWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -19,9 +19,9 @@
 
 GLWaveformWidget::GLWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -32,11 +32,6 @@ GLWaveformWidget::GLWaveformWidget(const QString& group, QWidget* parent)
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -59,7 +54,7 @@ mixxx::Duration GLWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/glwaveformwidget.h
+++ b/src/waveform/widgets/glwaveformwidget.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <QGLWidget>
-
 #include "waveform/widgets/glwaveformwidgetabstract.h"
 
 class GLWaveformWidget : public GLWaveformWidgetAbstract {

--- a/src/waveform/widgets/glwaveformwidgetabstract.cpp
+++ b/src/waveform/widgets/glwaveformwidgetabstract.cpp
@@ -1,0 +1,24 @@
+#include "waveform/widgets/glwaveformwidgetabstract.h"
+
+#include "widget/wwaveformviewer.h"
+
+GLWaveformWidgetAbstract::GLWaveformWidgetAbstract(const QString& group, QWidget* parent)
+        : WaveformWidgetAbstract(group),
+          WGLWidget(parent)
+#if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+          ,
+          m_pGlRenderer(nullptr)
+#endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+{
+}
+
+#ifdef MIXXX_USE_QOPENGL
+// We need to forward events coming from the QOpenGLWindow
+// (drag&drop, mouse) to the viewer
+void GLWaveformWidgetAbstract::handleEventFromWindow(QEvent* ev) {
+    auto viewer = dynamic_cast<WWaveformViewer*>(parent());
+    if (viewer) {
+        viewer->handleEventFromWindow(ev);
+    }
+}
+#endif

--- a/src/waveform/widgets/glwaveformwidgetabstract.h
+++ b/src/waveform/widgets/glwaveformwidgetabstract.h
@@ -1,29 +1,32 @@
 #pragma once
 
-#include <QGLWidget>
-
 #include "waveform/renderers/glwaveformrenderer.h"
-#include "waveform/sharedglcontext.h"
 #include "waveform/widgets/waveformwidgetabstract.h"
+#include "widget/wglwidget.h"
+#include "widget/wwaveformviewer.h"
 
 QT_FORWARD_DECLARE_CLASS(QString)
 
-/// GLWaveformWidgetAbstract is a WaveformWidgetAbstract & QGLWidget. Its optional
+/// GLWaveformWidgetAbstract is a WaveformWidgetAbstract & WGLWidget. Its optional
 /// member GLWaveformRenderer* m_pGlRenderer can implement a virtual method
 /// onInitializeGL, which will be called from GLWaveformRenderer::initializeGL
-/// (which overrides QGLWidget::initializeGL). This can be used for initialization
+/// (which overrides WGLWidget::initializeGL). This can be used for initialization
 /// that must be deferred until the GL context has been initialized and that can't
 /// be done in the constructor.
-class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public QGLWidget {
+class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public WGLWidget {
   public:
     GLWaveformWidgetAbstract(const QString& group, QWidget* parent)
             : WaveformWidgetAbstract(group),
-              QGLWidget(parent, SharedGLContext::getWidget())
+              WGLWidget(parent)
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
               ,
               m_pGlRenderer(nullptr)
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
     {
+    }
+
+    WGLWidget* getGLWidget() override {
+        return this;
     }
 
   protected:
@@ -33,6 +36,17 @@ class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public QGLWidget
             m_pGlRenderer->onInitializeGL();
         }
     }
+
+#ifdef MIXXX_USE_QOPENGL
+    // We need to forward events coming from the QOpenGLWindow
+    // (drag&drop, mouse) to the viewer
+    void handleEventFromWindow(QEvent* ev) override {
+        auto viewer = dynamic_cast<WWaveformViewer*>(parent());
+        if (viewer) {
+            viewer->handleEventFromWindow(ev);
+        }
+    }
+#endif
 
     GLWaveformRenderer* m_pGlRenderer;
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)

--- a/src/waveform/widgets/glwaveformwidgetabstract.h
+++ b/src/waveform/widgets/glwaveformwidgetabstract.h
@@ -3,7 +3,8 @@
 #include "waveform/renderers/glwaveformrenderer.h"
 #include "waveform/widgets/waveformwidgetabstract.h"
 #include "widget/wglwidget.h"
-#include "widget/wwaveformviewer.h"
+
+class WWaveformViewer;
 
 QT_FORWARD_DECLARE_CLASS(QString)
 
@@ -15,15 +16,7 @@ QT_FORWARD_DECLARE_CLASS(QString)
 /// be done in the constructor.
 class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public WGLWidget {
   public:
-    GLWaveformWidgetAbstract(const QString& group, QWidget* parent)
-            : WaveformWidgetAbstract(group),
-              WGLWidget(parent)
-#if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
-              ,
-              m_pGlRenderer(nullptr)
-#endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
-    {
-    }
+    GLWaveformWidgetAbstract(const QString& group, QWidget* parent);
 
     WGLWidget* getGLWidget() override {
         return this;
@@ -37,17 +30,12 @@ class GLWaveformWidgetAbstract : public WaveformWidgetAbstract, public WGLWidget
         }
     }
 
+    GLWaveformRenderer* m_pGlRenderer;
+
+  private:
 #ifdef MIXXX_USE_QOPENGL
-    // We need to forward events coming from the QOpenGLWindow
-    // (drag&drop, mouse) to the viewer
-    void handleEventFromWindow(QEvent* ev) override {
-        auto viewer = dynamic_cast<WWaveformViewer*>(parent());
-        if (viewer) {
-            viewer->handleEventFromWindow(ev);
-        }
-    }
+    void handleEventFromWindow(QEvent* ev) override;
 #endif
 
-    GLWaveformRenderer* m_pGlRenderer;
 #endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 };

--- a/src/waveform/widgets/qopengl/iwaveformwidget.h
+++ b/src/waveform/widgets/qopengl/iwaveformwidget.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace qopengl {
+class IWaveformWidget;
+}
+
+class qopengl::IWaveformWidget {
+  public:
+    virtual void renderGL() = 0;
+};

--- a/src/waveform/widgets/qopengl/rgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qopengl/rgbwaveformwidget.cpp
@@ -1,0 +1,36 @@
+#include "waveform/widgets/qopengl/rgbwaveformwidget.h"
+
+#include "waveform/renderers/qopengl/waveformrenderbackground.h"
+#include "waveform/renderers/qopengl/waveformrenderbeat.h"
+#include "waveform/renderers/qopengl/waveformrendererendoftrack.h"
+#include "waveform/renderers/qopengl/waveformrendererpreroll.h"
+#include "waveform/renderers/qopengl/waveformrendererrgb.h"
+#include "waveform/renderers/qopengl/waveformrendermark.h"
+#include "waveform/renderers/qopengl/waveformrendermarkrange.h"
+#include "waveform/widgets/qopengl/moc_rgbwaveformwidget.cpp"
+
+using namespace qopengl;
+
+RGBWaveformWidget::RGBWaveformWidget(const QString& group, QWidget* parent)
+        : WaveformWidget(group, parent) {
+    addRenderer<WaveformRenderBackground>();
+    addRenderer<WaveformRendererEndOfTrack>();
+    addRenderer<WaveformRendererPreroll>();
+    addRenderer<WaveformRenderMarkRange>();
+    addRenderer<WaveformRendererRGB>();
+    addRenderer<WaveformRenderBeat>();
+    addRenderer<WaveformRenderMark>();
+
+    m_initSuccess = init();
+}
+
+RGBWaveformWidget::~RGBWaveformWidget() {
+}
+
+void RGBWaveformWidget::castToQWidget() {
+    m_widget = this;
+}
+
+void RGBWaveformWidget::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event);
+}

--- a/src/waveform/widgets/qopengl/rgbwaveformwidget.h
+++ b/src/waveform/widgets/qopengl/rgbwaveformwidget.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "waveform/widgets/qopengl/waveformwidget.h"
+
+class WaveformWidgetFactory;
+
+namespace qopengl {
+class RGBWaveformWidget;
+}
+
+class qopengl::RGBWaveformWidget : public qopengl::WaveformWidget {
+    Q_OBJECT
+  public:
+    ~RGBWaveformWidget() override;
+
+    WaveformWidgetType::Type getType() const override {
+        return WaveformWidgetType::QOpenGLRGBWaveform;
+    }
+
+    static inline QString getWaveformWidgetName() {
+        return tr("RGB (QOpenGL)");
+    }
+    static inline bool useOpenGl() {
+        return true;
+    }
+    static inline bool useOpenGles() {
+        return false;
+    }
+    static inline bool useOpenGLShaders() {
+        return true;
+    }
+    static inline bool developerOnly() {
+        return false;
+    }
+
+  protected:
+    void castToQWidget() override;
+    void paintEvent(QPaintEvent* event) override;
+
+  private:
+    RGBWaveformWidget(const QString& group, QWidget* parent);
+    friend class ::WaveformWidgetFactory;
+};

--- a/src/waveform/widgets/qopengl/waveformwidget.cpp
+++ b/src/waveform/widgets/qopengl/waveformwidget.cpp
@@ -1,0 +1,50 @@
+#include "waveform/widgets/qopengl/waveformwidget.h"
+
+#include "waveform/renderers/qopengl/iwaveformrenderer.h"
+#include "widget/wwaveformviewer.h"
+
+using namespace qopengl;
+
+WaveformWidget::WaveformWidget(const QString& group, QWidget* parent)
+        : WGLWidget(parent), WaveformWidgetAbstract(group) {
+}
+
+WaveformWidget::~WaveformWidget() {
+    makeCurrentIfNeeded();
+    for (int i = 0; i < m_rendererStack.size(); ++i) {
+        delete m_rendererStack[i];
+    }
+    m_rendererStack.clear();
+    doneCurrent();
+}
+
+void WaveformWidget::renderGL() {
+    makeCurrentIfNeeded();
+
+    if (shouldOnlyDrawBackground()) {
+        if (!m_rendererStack.empty()) {
+            m_rendererStack[0]->qopenglWaveformRenderer()->renderGL();
+        }
+    } else {
+        for (int i = 0; i < m_rendererStack.size(); ++i) {
+            m_rendererStack[i]->qopenglWaveformRenderer()->renderGL();
+        }
+    }
+    doneCurrent();
+}
+
+void WaveformWidget::initializeGL() {
+    makeCurrentIfNeeded();
+    for (int i = 0; i < m_rendererStack.size(); ++i) {
+        m_rendererStack[i]->qopenglWaveformRenderer()->initializeOpenGLFunctions();
+        m_rendererStack[i]->qopenglWaveformRenderer()->initializeGL();
+    }
+    doneCurrent();
+}
+
+void WaveformWidget::handleEventFromWindow(QEvent* ev) {
+    auto viewer = dynamic_cast<WWaveformViewer*>(parent());
+    if (viewer) {
+        viewer->handleEventFromWindow(ev);
+    }
+}

--- a/src/waveform/widgets/qopengl/waveformwidget.h
+++ b/src/waveform/widgets/qopengl/waveformwidget.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "waveform/widgets/qopengl/iwaveformwidget.h"
+#include "waveform/widgets/waveformwidgetabstract.h"
+#include "widget/wglwidget.h"
+
+class WWaveformViewer;
+
+namespace qopengl {
+class WaveformWidget;
+}
+
+class qopengl::WaveformWidget : public ::WGLWidget,
+                                public ::WaveformWidgetAbstract,
+                                public qopengl::IWaveformWidget {
+    Q_OBJECT
+  public:
+    explicit WaveformWidget(const QString& group, QWidget* parent);
+    ~WaveformWidget() override;
+
+    qopengl::IWaveformWidget* qopenglWaveformWidget() override {
+        return this;
+    }
+
+    // override for IWaveformWidget
+    void renderGL() override;
+
+    // overrides for WGLWidget
+    void initializeGL() override;
+
+    virtual WGLWidget* getGLWidget() override {
+        return this;
+    }
+
+  private:
+    // We need to forward events coming from the QOpenGLWindow
+    // (drag&drop, mouse) to the viewer
+    void handleEventFromWindow(QEvent* ev) override;
+};

--- a/src/waveform/widgets/qthsvwaveformwidget.cpp
+++ b/src/waveform/widgets/qthsvwaveformwidget.cpp
@@ -16,9 +16,7 @@
 
 QtHSVWaveformWidget::QtHSVWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
+    makeCurrentIfNeeded();
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -26,9 +24,6 @@ QtHSVWaveformWidget::QtHSVWaveformWidget(const QString& group, QWidget* parent)
     addRenderer<WaveformRendererHSV>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
 
     m_initSuccess = init();
 }
@@ -51,7 +46,7 @@ mixxx::Duration QtHSVWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -13,13 +13,12 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtRGBWaveformWidget::QtRGBWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -28,11 +27,6 @@ QtRGBWaveformWidget::QtRGBWaveformWidget(const QString& group, QWidget* parent)
     addRenderer<WaveformRendererRGB>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -55,7 +49,7 @@ mixxx::Duration QtRGBWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/qtsimplewaveformwidget.cpp
@@ -13,15 +13,14 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtSimpleWaveformWidget::QtSimpleWaveformWidget(
         const QString& group,
         QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -30,11 +29,6 @@ QtSimpleWaveformWidget::QtSimpleWaveformWidget(
     addRenderer<QtWaveformRendererSimpleSignal>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -58,7 +52,7 @@ mixxx::Duration QtSimpleWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -14,20 +14,14 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtVSyncTestWidget::QtVSyncTestWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<QtVSyncTestRenderer>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -50,7 +44,7 @@ mixxx::Duration QtVSyncTestWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -14,13 +14,12 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
-#include "waveform/sharedglcontext.h"
 
 QtWaveformWidget::QtWaveformWidget(const QString& group, QWidget* parent)
         : GLWaveformWidgetAbstract(group, parent) {
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
+    qDebug() << "Created WGLWidget. Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -29,11 +28,6 @@ QtWaveformWidget::QtWaveformWidget(const QString& group, QWidget* parent)
     addRenderer<QtWaveformRendererFilteredSignal>();
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoBufferSwap(false);
 
     m_initSuccess = init();
 }
@@ -56,7 +50,7 @@ mixxx::Duration QtWaveformWidget::render() {
     timer.start();
     // QPainter makes QGLContext::currentContext() == context()
     // this may delayed until previous buffer swap finished
-    QPainter painter(this);
+    QPainter painter(paintDevice());
     t1 = timer.restart();
     draw(&painter, nullptr);
     //t2 = timer.restart();

--- a/src/waveform/widgets/waveformwidgetabstract.h
+++ b/src/waveform/widgets/waveformwidgetabstract.h
@@ -6,12 +6,13 @@
 #include "util/duration.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveformwidgettype.h"
+#include "widget/wglwidget.h"
 
 class VSyncThread;
 
 // NOTE(vRince) This class represent objects the waveformwidgetfactory can
 // holds, IMPORTANT all WaveformWidgetAbstract MUST inherist QWidget too !!  we
-// can't do it here because QWidget and QGLWidget are both QWidgets so they
+// can't do it here because QWidget and WGLWidget are both QWidgets so they
 // already have a common QWidget base class (ambiguous polymorphism)
 
 class WaveformWidgetAbstract : public WaveformWidgetRenderer {
@@ -24,6 +25,10 @@ class WaveformWidgetAbstract : public WaveformWidgetRenderer {
 
     bool isValid() const { return (m_widget && m_initSuccess); }
     QWidget* getWidget() { return m_widget; }
+
+    virtual WGLWidget* getGLWidget() {
+        return nullptr;
+    }
 
     void hold();
     void release();

--- a/src/waveform/widgets/waveformwidgetabstract.h
+++ b/src/waveform/widgets/waveformwidgetabstract.h
@@ -8,6 +8,12 @@
 #include "waveformwidgettype.h"
 #include "widget/wglwidget.h"
 
+#ifdef MIXXX_USE_QOPENGL
+namespace qopengl {
+class IWaveformWidget;
+}
+#endif
+
 class VSyncThread;
 
 // NOTE(vRince) This class represent objects the waveformwidgetfactory can
@@ -29,6 +35,14 @@ class WaveformWidgetAbstract : public WaveformWidgetRenderer {
     virtual WGLWidget* getGLWidget() {
         return nullptr;
     }
+
+#ifdef MIXXX_USE_QOPENGL
+    // Derived classes that implement the IWaveformWidget
+    // interface should return this
+    virtual qopengl::IWaveformWidget* qopenglWaveformWidget() {
+        return nullptr;
+    }
+#endif
 
     void hold();
     void release();

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -6,22 +6,25 @@ class WaveformWidgetType {
         // The order must not be changed because the waveforms are referenced
         // from the sorted preferences by a number.
         EmptyWaveform = 0,
-        SoftwareSimpleWaveform,  // 1  TODO
-        SoftwareWaveform,        // 2  Filtered
-        QtSimpleWaveform,        // 3  Simple Qt
-        QtWaveform,              // 4  Filtered Qt
-        GLSimpleWaveform,        // 5  Simple GL
-        GLFilteredWaveform,      // 6  Filtered GL
-        GLSLFilteredWaveform,    // 7  Filtered GLSL
-        HSVWaveform,             // 8  HSV
-        GLVSyncTest,             // 9  VSync GL
-        RGBWaveform,             // 10 RGB
-        GLRGBWaveform,           // 11 RGB GL
-        GLSLRGBWaveform,         // 12 RGB GLSL
-        QtVSyncTest,             // 13 VSync Qt
-        QtHSVWaveform,           // 14 HSV Qt
-        QtRGBWaveform,           // 15 RGB Qt
-        GLSLRGBStackedWaveform,  // 16 RGB Stacked
-        Count_WaveformwidgetType // 17 Also used as invalid value
+        SoftwareSimpleWaveform, // 1  TODO
+        SoftwareWaveform,       // 2  Filtered
+        QtSimpleWaveform,       // 3  Simple Qt
+        QtWaveform,             // 4  Filtered Qt
+        GLSimpleWaveform,       // 5  Simple GL
+        GLFilteredWaveform,     // 6  Filtered GL
+        GLSLFilteredWaveform,   // 7  Filtered GLSL
+        HSVWaveform,            // 8  HSV
+        GLVSyncTest,            // 9  VSync GL
+        RGBWaveform,            // 10 RGB
+        GLRGBWaveform,          // 11 RGB GL
+        GLSLRGBWaveform,        // 12 RGB GLSL
+        QtVSyncTest,            // 13 VSync Qt
+        QtHSVWaveform,          // 14 HSV Qt
+        QtRGBWaveform,          // 15 RGB Qt
+        GLSLRGBStackedWaveform, // 16 RGB Stacked
+#ifdef MIXXX_USE_QOPENGL
+        QOpenGLRGBWaveform, // 17 RGB (QOpenGL)
+#endif
+        Count_WaveformwidgetType //    Also used as invalid value
     };
 };

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -32,14 +32,11 @@ bool OpenGLWindow::event(QEvent* ev) {
 
     if (m_pWidget) {
         const auto t = ev->type();
-        if (t == QEvent::Expose) {
-            m_pWidget->exposed();
-        }
         // Forward the following events to the WGLWidget
-        else if (t == QEvent::MouseButtonDblClick || t == QEvent::MouseButtonPress ||
+        if (t == QEvent::MouseButtonDblClick || t == QEvent::MouseButtonPress ||
                 t == QEvent::MouseButtonRelease || t == QEvent::MouseMove ||
                 t == QEvent::DragEnter || t == QEvent::DragLeave ||
-                t == QEvent::DragMove || t == QEvent::Drop) {
+                t == QEvent::DragMove || t == QEvent::Drop || t == QEvent::Wheel) {
             m_pWidget->handleEventFromWindow(ev);
         }
     }

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -1,0 +1,48 @@
+#include "widget/openglwindow.h"
+
+#include <QResizeEvent>
+
+#include "widget/wglwidget.h"
+
+OpenGLWindow::OpenGLWindow(WGLWidget* widget)
+        : m_pWidget(widget) {
+}
+
+OpenGLWindow::~OpenGLWindow() {
+}
+
+void OpenGLWindow::initializeGL() {
+    if (m_pWidget) {
+        m_pWidget->initializeGL();
+    }
+}
+
+void OpenGLWindow::paintGL() {
+}
+
+void OpenGLWindow::resizeGL(int w, int h) {
+}
+
+void OpenGLWindow::widgetDestroyed() {
+    m_pWidget = nullptr;
+}
+
+bool OpenGLWindow::event(QEvent* ev) {
+    bool result = QOpenGLWindow::event(ev);
+
+    if (m_pWidget) {
+        const auto t = ev->type();
+        if (t == QEvent::Expose) {
+            m_pWidget->exposed();
+        }
+        // Forward the following events to the WGLWidget
+        else if (t == QEvent::MouseButtonDblClick || t == QEvent::MouseButtonPress ||
+                t == QEvent::MouseButtonRelease || t == QEvent::MouseMove ||
+                t == QEvent::DragEnter || t == QEvent::DragLeave ||
+                t == QEvent::DragMove || t == QEvent::Drop) {
+            m_pWidget->handleEventFromWindow(ev);
+        }
+    }
+
+    return result;
+}

--- a/src/widget/openglwindow.h
+++ b/src/widget/openglwindow.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QOpenGLWindow>
+
+class WGLWidget;
+
+/// Helper class used by wglwidgetqopengl
+
+class OpenGLWindow : public QOpenGLWindow {
+    Q_OBJECT
+
+    WGLWidget* m_pWidget;
+
+  public:
+    OpenGLWindow(WGLWidget* widget);
+    ~OpenGLWindow();
+
+    void widgetDestroyed();
+
+  private:
+    void initializeGL() override;
+    void paintGL() override;
+    void resizeGL(int w, int h) override;
+    bool event(QEvent* ev) override;
+};

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -134,6 +134,10 @@ QRectF Paintable::rect() const {
     return QRectF();
 }
 
+QImage Paintable::toImage() const {
+    return m_pPixmap.isNull() ? QImage() : m_pPixmap->toImage();
+}
+
 void Paintable::draw(const QRectF& targetRect, QPainter* pPainter) {
     // The sourceRect is implicitly the entire Paintable.
     draw(targetRect, pPainter, rect());

--- a/src/widget/paintable.h
+++ b/src/widget/paintable.h
@@ -34,6 +34,7 @@ class Paintable {
     int width() const;
     int height() const;
     QRectF rect() const;
+    QImage toImage() const;
     DrawMode drawMode() const {
         return m_drawMode;
     }

--- a/src/widget/qopengl/wspinny.h
+++ b/src/widget/qopengl/wspinny.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#ifdef MIXXX_USE_QOPENGL
-#include "widget/qopengl/wspinny.h"
-#else
-
 #include <QEvent>
 #include <QHideEvent>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLTexture>
 #include <QShowEvent>
 
 #include "library/dlgcoverartfullsize.h"
@@ -32,7 +30,8 @@ class WSpinny : public WGLWidget,
                 public TrackDropTarget {
     Q_OBJECT
   public:
-    WSpinny(QWidget* parent, const QString& group,
+    WSpinny(QWidget* parent,
+            const QString& group,
             UserSettingsPointer pConfig,
             VinylControlManager* pVCMan,
             BaseTrackPlayer* pPlayer);
@@ -43,8 +42,8 @@ class WSpinny : public WGLWidget,
     void setup(const QDomNode& node,
             const SkinContext& context,
             const ConfigKey& showCoverConfigKey);
-    void dragEnterEvent(QDragEnterEvent *event) override;
-    void dropEvent(QDropEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
 
   public slots:
     void slotLoadTrack(TrackPointer);
@@ -67,7 +66,6 @@ class WSpinny : public WGLWidget,
     void slotReloadCoverArt();
     void slotTrackCoverArtUpdated();
 
-
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
@@ -75,9 +73,9 @@ class WSpinny : public WGLWidget,
   protected:
     //QWidget:
     void paintEvent(QPaintEvent* /*unused*/) override;
-    void mouseMoveEvent(QMouseEvent * e) override;
-    void mousePressEvent(QMouseEvent * e) override;
-    void mouseReleaseEvent(QMouseEvent * e) override;
+    void mouseMoveEvent(QMouseEvent* e) override;
+    void mousePressEvent(QMouseEvent* e) override;
+    void mouseReleaseEvent(QMouseEvent* e) override;
     void resizeEvent(QResizeEvent* /*unused*/) override;
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
@@ -115,7 +113,6 @@ class WSpinny : public WGLWidget,
     CoverInfo m_lastRequestedCover;
     bool m_bShowCover;
 
-
     VinylControlManager* m_pVCManager;
     double m_dInitialPos;
 
@@ -143,6 +140,15 @@ class WSpinny : public WGLWidget,
     BaseTrackPlayer* m_pPlayer;
     WCoverArtMenu* m_pCoverMenu;
     DlgCoverArtFullSize* m_pDlgCoverArt;
-};
 
-#endif // not defined MIXXX_USE_QOPENGL
+    void initializeGL() override;
+    void drawTexture(QOpenGLTexture* texture);
+
+    QOpenGLShaderProgram m_shaderProgram;
+    std::unique_ptr<QOpenGLTexture> m_pBgTexture;
+    std::unique_ptr<QOpenGLTexture> m_pMaskTexture;
+    std::unique_ptr<QOpenGLTexture> m_pFgTextureScaled;
+    std::unique_ptr<QOpenGLTexture> m_pGhostTextureScaled;
+    std::unique_ptr<QOpenGLTexture> m_pLoadedCoverTextureScaled;
+    std::unique_ptr<QOpenGLTexture> m_pQTexture;
+};

--- a/src/widget/qopengl/wvumetergl.h
+++ b/src/widget/qopengl/wvumetergl.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#ifdef MIXXX_USE_QOPENGL
-#include "widget/qopengl/wvumetergl.h"
-#else
+#include <QOpenGLFunctions>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLTexture>
+#include <memory>
 
 #include "skin/legacy/skincontext.h"
 #include "util/duration.h"
@@ -16,6 +17,7 @@ class WVuMeterGL : public WGLWidget, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WVuMeterGL(QWidget* parent = nullptr);
+    ~WVuMeterGL() override;
 
     void setup(const QDomNode& node, const SkinContext& context);
     void setPixmapBackground(
@@ -29,6 +31,8 @@ class WVuMeterGL : public WGLWidget, public WBaseWidget {
             double scaleFactor);
     void onConnectedControlChanged(double dParameter, double dValue) override;
 
+    void initializeGL() override;
+
   public slots:
     void render(VSyncThread* vSyncThread);
     void swap();
@@ -37,6 +41,9 @@ class WVuMeterGL : public WGLWidget, public WBaseWidget {
     void updateState(mixxx::Duration elapsed);
 
   private:
+    void drawNativeGL();
+    void drawTexture(QOpenGLTexture* texture, const QRectF& sourceRect, const QRectF& targetRect);
+
     void paintEvent(QPaintEvent* /*unused*/) override;
     void showEvent(QShowEvent* /*unused*/) override;
     void setPeak(double parameter);
@@ -74,6 +81,8 @@ class WVuMeterGL : public WGLWidget, public WBaseWidget {
     double m_dPeakHoldCountdownMs;
 
     QColor m_qBgColor;
-};
 
-#endif // not defined MIXXX_USE_QOPENGL
+    std::unique_ptr<QOpenGLTexture> m_pTextureBack;
+    std::unique_ptr<QOpenGLTexture> m_pTextureVu;
+    QOpenGLShaderProgram m_shaderProgram;
+};

--- a/src/widget/wglwidget.h
+++ b/src/widget/wglwidget.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// This define is checked in wglwidgetqglwidget.h and wglwidgetqglwidget.h
+// to make sure they are only included from this header, to enforce that
+// all code includes this header wglwidget.h.
+#define WGLWIDGET_H
+
+#ifdef MIXXX_USE_QOPENGL
+#include "widget/wglwidgetqopengl.h"
+#else
+#include "widget/wglwidgetqglwidget.h"
+#endif
+
+#undef WGLWIDGET_H

--- a/src/widget/wglwidgetqglwidget.cpp
+++ b/src/widget/wglwidgetqglwidget.cpp
@@ -1,0 +1,34 @@
+#include <QWindow>
+
+#include "waveform/sharedglcontext.h"
+#include "widget/wglwidget.h"
+
+WGLWidget::WGLWidget(QWidget* parent)
+        : QGLWidget(parent, SharedGLContext::getWidget()) {
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    setAutoFillBackground(false);
+    setAutoBufferSwap(false);
+    // Not interested in repaint or update calls, as we draw from the vsync thread
+    setUpdatesEnabled(false);
+}
+
+bool WGLWidget::isContextValid() const {
+    return context()->isValid();
+}
+
+bool WGLWidget::isContextSharing() const {
+    return context()->isSharing();
+}
+
+bool WGLWidget::shouldRender() const {
+    return true;
+    return isValid() && isVisible() && windowHandle() && windowHandle()->isExposed();
+}
+
+void WGLWidget::makeCurrentIfNeeded() {
+    // TODO m0dB is this really needed? is calling makeCurrent without this 'if' really a problem?
+    //if (context() != QGLContext::currentContext()) {
+    makeCurrent();
+    //}
+}

--- a/src/widget/wglwidgetqglwidget.h
+++ b/src/widget/wglwidgetqglwidget.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifndef WGLWIDGET_H
+#error "Do not include this file, include wglwidget.h instead"
+#endif
+
+#include <QGLWidget>
+
+///////////////////////////////////////
+// WGLWidget as a subclass of QGLWidget
+///////////////////////////////////////
+
+class WGLWidget : public QGLWidget {
+  public:
+    WGLWidget(QWidget* parent);
+
+    bool isContextValid() const;
+    bool isContextSharing() const;
+
+    bool shouldRender() const;
+
+    void makeCurrentIfNeeded();
+
+    QPaintDevice* paintDevice() {
+        return this;
+    }
+};

--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -62,14 +62,11 @@ void WGLWidget::initializeGL() {
     // to be implemented in derived widgets if needed
 }
 
-void WGLWidget::exposed() {
-    // to be implemented in derived widgets if needed
-}
-
 void WGLWidget::swapBuffers() {
     if (shouldRender()) {
         makeCurrentIfNeeded();
         m_pOpenGLWindow->context()->swapBuffers(m_pOpenGLWindow->context()->surface());
+        doneCurrent();
     }
 }
 

--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -1,0 +1,78 @@
+#include <QResizeEvent>
+
+#include "widget/openglwindow.h"
+#include "widget/wglwidget.h"
+
+WGLWidget::WGLWidget(QWidget* parent)
+        : QWidget(parent) {
+}
+
+WGLWidget::~WGLWidget() {
+    if (m_pOpenGLWindow) {
+        m_pOpenGLWindow->widgetDestroyed();
+    }
+}
+
+QPaintDevice* WGLWidget::paintDevice() {
+    makeCurrentIfNeeded();
+    return m_pOpenGLWindow;
+}
+
+void WGLWidget::showEvent(QShowEvent* event) {
+    if (!m_pOpenGLWindow) {
+        m_pOpenGLWindow = new OpenGLWindow(this);
+        m_pContainerWidget = createWindowContainer(m_pOpenGLWindow, this);
+        m_pContainerWidget->resize(size());
+        m_pContainerWidget->show();
+    }
+    QWidget::showEvent(event);
+}
+
+void WGLWidget::resizeEvent(QResizeEvent* event) {
+    if (m_pContainerWidget) {
+        m_pContainerWidget->resize(event->size());
+    }
+}
+
+void WGLWidget::handleEventFromWindow(QEvent* e) {
+    event(e);
+}
+
+bool WGLWidget::isContextValid() const {
+    return m_pOpenGLWindow && m_pOpenGLWindow->context() && m_pOpenGLWindow->context()->isValid();
+}
+
+bool WGLWidget::isContextSharing() const {
+    return true;
+}
+
+void WGLWidget::makeCurrentIfNeeded() {
+    if (m_pOpenGLWindow && m_pOpenGLWindow->context() != QOpenGLContext::currentContext()) {
+        m_pOpenGLWindow->makeCurrent();
+    }
+}
+
+void WGLWidget::doneCurrent() {
+    if (m_pOpenGLWindow) {
+        m_pOpenGLWindow->doneCurrent();
+    }
+}
+
+void WGLWidget::initializeGL() {
+    // to be implemented in derived widgets if needed
+}
+
+void WGLWidget::exposed() {
+    // to be implemented in derived widgets if needed
+}
+
+void WGLWidget::swapBuffers() {
+    if (shouldRender()) {
+        makeCurrentIfNeeded();
+        m_pOpenGLWindow->context()->swapBuffers(m_pOpenGLWindow->context()->surface());
+    }
+}
+
+bool WGLWidget::shouldRender() const {
+    return m_pOpenGLWindow && m_pOpenGLWindow->isExposed();
+}

--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -8,6 +8,7 @@ WGLWidget::WGLWidget(QWidget* parent)
 }
 
 WGLWidget::~WGLWidget() {
+    disconnect(m_pContainerWidget);
     if (m_pOpenGLWindow) {
         m_pOpenGLWindow->widgetDestroyed();
     }
@@ -24,6 +25,8 @@ void WGLWidget::showEvent(QShowEvent* event) {
         m_pContainerWidget = createWindowContainer(m_pOpenGLWindow, this);
         m_pContainerWidget->resize(size());
         m_pContainerWidget->show();
+        
+        connect(m_pOpenGLWindow, &QOpenGLWindow::frameSwapped, m_pContainerWidget, qOverload<>(&QWidget::update));
     }
     QWidget::showEvent(event);
 }
@@ -67,6 +70,7 @@ void WGLWidget::swapBuffers() {
         makeCurrentIfNeeded();
         m_pOpenGLWindow->context()->swapBuffers(m_pOpenGLWindow->context()->surface());
         doneCurrent();
+        emit m_pOpenGLWindow->frameSwapped();
     }
 }
 

--- a/src/widget/wglwidgetqopengl.h
+++ b/src/widget/wglwidgetqopengl.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#ifndef WGLWIDGET_H
+#error "Do not include this file, include wglwidget.h instead"
+#endif
+
+#include <QWidget>
+
+////////////////////////////////
+// QOpenGLWindow based WGLWidget
+////////////////////////////////
+
+class QPaintDevice;
+class OpenGLWindow;
+
+class WGLWidget : public QWidget {
+  private:
+    OpenGLWindow* m_pOpenGLWindow{};
+    QWidget* m_pContainerWidget{};
+
+  public:
+    WGLWidget(QWidget* parent);
+    ~WGLWidget();
+
+    bool isContextValid() const;
+    bool isContextSharing() const;
+
+    bool shouldRender() const;
+
+    void makeCurrentIfNeeded();
+    void doneCurrent();
+
+    void swapBuffers();
+    void resizeEvent(QResizeEvent* event) override;
+
+    void showEvent(QShowEvent* event) override;
+
+    // called by OpenGLWindow
+    virtual void handleEventFromWindow(QEvent* ev);
+    virtual void initializeGL();
+    virtual void exposed();
+
+  protected:
+    QPaintDevice* paintDevice();
+};

--- a/src/widget/wglwidgetqopengl.h
+++ b/src/widget/wglwidgetqopengl.h
@@ -38,7 +38,6 @@ class WGLWidget : public QWidget {
     // called by OpenGLWindow
     virtual void handleEventFromWindow(QEvent* ev);
     virtual void initializeGL();
-    virtual void exposed();
 
   protected:
     QPaintDevice* paintDevice();

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -8,13 +8,18 @@
 #include "util/duration.h"
 
 WKnob::WKnob(QWidget* pParent)
-        : WDisplay(pParent),
+        : WDisplay(pParent)
+#ifdef USE_WIDGET_RENDER_TIMER
+          ,
           m_renderTimer(mixxx::Duration::fromMillis(20),
-                        mixxx::Duration::fromSeconds(1)) {
+                  mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer,
             &WidgetRenderTimer::update,
             this,
             QOverload<>::of(&QWidget::update));
+#else
+{
+#endif
     setFocusPolicy(Qt::NoFocus);
 }
 
@@ -39,7 +44,7 @@ void WKnob::wheelEvent(QWheelEvent* e) {
 }
 
 void WKnob::inputActivity() {
-#ifdef __APPLE__
+#ifdef USE_WIDGET_RENDER_TIMER
     m_renderTimer.activity();
 #else
     update();

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -28,8 +28,9 @@ class WKnob : public WDisplay {
     void inputActivity();
 
   private:
+#ifdef USE_WIDGET_RENDER_TIMER
     WidgetRenderTimer m_renderTimer;
-
+#endif
     KnobEventHandler<WKnob> m_handler;
     friend class KnobEventHandler<WKnob>;
 };

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -20,13 +20,18 @@ WKnobComposed::WKnobComposed(QWidget* pParent)
           m_dArcBgThickness(0),
           m_arcUnipolar(true),
           m_arcReversed(false),
-          m_arcPenCap(Qt::FlatCap),
+          m_arcPenCap(Qt::FlatCap)
+#ifdef USE_WIDGET_RENDER_TIMER
+          ,
           m_renderTimer(mixxx::Duration::fromMillis(20),
-                        mixxx::Duration::fromSeconds(1)) {
+                  mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer,
             &WidgetRenderTimer::update,
             this,
             QOverload<>::of(&QWidget::update));
+#else
+{
+#endif
 }
 
 void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
@@ -228,7 +233,7 @@ void WKnobComposed::wheelEvent(QWheelEvent* e) {
 }
 
 void WKnobComposed::inputActivity() {
-#ifdef __APPLE__
+#ifdef USE_WIDGET_RENDER_TIMER
     m_renderTimer.activity();
 #else
     update();

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -63,7 +63,9 @@ class WKnobComposed : public WWidget {
     bool m_arcUnipolar;
     bool m_arcReversed;
     Qt::PenCapStyle m_arcPenCap;
+#ifdef USE_WIDGET_RENDER_TIMER
     WidgetRenderTimer m_renderTimer;
+#endif
 
     friend class KnobEventHandler<WKnobComposed>;
 };

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -12,30 +12,35 @@
 #include "widget/wpixmapstore.h"
 #include "widget/wskincolor.h"
 
-WSliderComposed::WSliderComposed(QWidget * parent)
-    : WWidget(parent),
-      m_dHandleLength(0.0),
-      m_dSliderLength(0.0),
-      m_bHorizontal(false),
-      m_dBarWidth(0.0),
-      m_dBarBgWidth(0.0),
-      m_dBarStart(0.0),
-      m_dBarEnd(0.0),
-      m_dBarBgStart(0.0),
-      m_dBarBgEnd(0.0),
-      m_dBarAxisPos(0.0),
-      m_bBarUnipolar(true),
-      m_barColor(nullptr),
-      m_barBgColor(nullptr),
-      m_barPenCap(Qt::FlatCap),
-      m_pSlider(nullptr),
-      m_pHandle(nullptr),
-      m_renderTimer(mixxx::Duration::fromMillis(20),
-                    mixxx::Duration::fromSeconds(1)) {
+WSliderComposed::WSliderComposed(QWidget* parent)
+        : WWidget(parent),
+          m_dHandleLength(0.0),
+          m_dSliderLength(0.0),
+          m_bHorizontal(false),
+          m_dBarWidth(0.0),
+          m_dBarBgWidth(0.0),
+          m_dBarStart(0.0),
+          m_dBarEnd(0.0),
+          m_dBarBgStart(0.0),
+          m_dBarBgEnd(0.0),
+          m_dBarAxisPos(0.0),
+          m_bBarUnipolar(true),
+          m_barColor(nullptr),
+          m_barBgColor(nullptr),
+          m_barPenCap(Qt::FlatCap),
+          m_pSlider(nullptr),
+          m_pHandle(nullptr)
+#ifdef USE_WIDGET_RENDER_TIMER
+          ,
+          m_renderTimer(mixxx::Duration::fromMillis(20),
+                  mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer,
             &WidgetRenderTimer::update,
             this,
             QOverload<>::of(&QWidget::update));
+#else
+                  {
+#endif
 }
 
 WSliderComposed::~WSliderComposed() {
@@ -371,7 +376,7 @@ double WSliderComposed::calculateHandleLength() {
 }
 
 void WSliderComposed::inputActivity() {
-#ifdef __APPLE__
+#ifdef USE_WIDGET_RENDER_TIMER
     m_renderTimer.activity();
 #else
     update();

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -75,7 +75,9 @@ class WSliderComposed : public WWidget  {
     // Pointer to pixmap of the handle
     PaintablePointer m_pHandle;
     SliderEventHandler<WSliderComposed> m_handler;
+#ifdef USE_WIDGET_RENDER_TIMER
     WidgetRenderTimer m_renderTimer;
+#endif
 
     friend class SliderEventHandler<WSliderComposed>;
 };

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -17,7 +17,6 @@
 #include "util/fpclassify.h"
 #include "vinylcontrol/vinylcontrol.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
-#include "waveform/sharedglcontext.h"
 #include "waveform/visualplayposition.h"
 #include "waveform/vsyncthread.h"
 #include "wimagestore.h"
@@ -29,7 +28,7 @@ WSpinny::WSpinny(
         UserSettingsPointer pConfig,
         VinylControlManager* pVCMan,
         BaseTrackPlayer* pPlayer)
-        : QGLWidget(parent, SharedGLContext::getWidget()),
+        : WGLWidget(parent),
           WBaseWidget(this),
           m_group(group),
           m_pConfig(pConfig),
@@ -72,12 +71,10 @@ WSpinny::WSpinny(
 #endif // __VINYLCONTROL__
     //Drag and drop
     setAcceptDrops(true);
-    qDebug() << "WSpinny(): Created QGLWidget, Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
+    qDebug() << "WSpinny(): Created WGLWidget, Context"
+             << "Valid:" << isContextValid()
+             << "Sharing:" << isContextSharing();
+    makeCurrentIfNeeded();
 
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
@@ -96,12 +93,6 @@ WSpinny::WSpinny(
 
     connect(m_pCoverMenu, &WCoverArtMenu::coverInfoSelected, this, &WSpinny::slotCoverInfoSelected);
     connect(m_pCoverMenu, &WCoverArtMenu::reloadCoverArt, this, &WSpinny::slotReloadCoverArt);
-
-    setAttribute(Qt::WA_NoSystemBackground);
-    setAttribute(Qt::WA_OpaquePaintEvent);
-
-    setAutoFillBackground(false);
-    setAutoBufferSwap(false);
 }
 
 WSpinny::~WSpinny() {
@@ -328,12 +319,8 @@ void WSpinny::paintEvent(QPaintEvent *e) {
 }
 
 void WSpinny::render(VSyncThread* vSyncThread) {
-    if (!isValid() || !isVisible()) {
-        return;
-    }
-
-    auto* window = windowHandle();
-    if (window == nullptr || !window->isExposed()) {
+    // TODO @m0dB move outside?
+    if (!shouldRender()) {
         return;
     }
 
@@ -346,7 +333,7 @@ void WSpinny::render(VSyncThread* vSyncThread) {
 
     double scaleFactor = devicePixelRatioF();
 
-    QPainter p(this);
+    QPainter p(paintDevice());
     p.setRenderHint(QPainter::Antialiasing);
     p.setRenderHint(QPainter::SmoothPixmapTransform);
 
@@ -415,16 +402,11 @@ void WSpinny::render(VSyncThread* vSyncThread) {
 }
 
 void WSpinny::swap() {
-    if (!isValid() || !isVisible()) {
+    // TODO @m0dB move outside?
+    if (!shouldRender()) {
         return;
     }
-    auto* window = windowHandle();
-    if (window == nullptr || !window->isExposed()) {
-        return;
-    }
-    if (context() != QGLContext::currentContext()) {
-        makeCurrent();
-    }
+    makeCurrentIfNeeded();
     swapBuffers();
 }
 
@@ -439,7 +421,7 @@ QPixmap WSpinny::scaledCoverArt(const QPixmap& normal) {
     return scaled;
 }
 
-void WSpinny::resizeEvent(QResizeEvent* /*unused*/) {
+void WSpinny::resizeEvent(QResizeEvent* event) {
     m_loadedCoverScaled = scaledCoverArt(m_loadedCover);
     if (m_pFgImage && !m_pFgImage->isNull()) {
         m_fgImageScaled = m_pFgImage->scaled(
@@ -449,6 +431,7 @@ void WSpinny::resizeEvent(QResizeEvent* /*unused*/) {
         m_ghostImageScaled = m_pGhostImage->scaled(
                 size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }
+    WGLWidget::resizeEvent(event);
 }
 
 /* Convert between a normalized playback position (0.0 - 1.0) and an angle
@@ -691,6 +674,7 @@ void WSpinny::mouseReleaseEvent(QMouseEvent * e)
 
 void WSpinny::showEvent(QShowEvent* event) {
     Q_UNUSED(event);
+    WGLWidget::showEvent(event);
 #ifdef __VINYLCONTROL__
     // If we want to draw the VC signal on this widget then register for
     // updates.
@@ -716,7 +700,7 @@ bool WSpinny::event(QEvent* pEvent) {
     if (pEvent->type() == QEvent::ToolTip) {
         updateTooltip();
     }
-    return QGLWidget::event(pEvent);
+    return WGLWidget::event(pEvent);
 }
 
 void WSpinny::dragEnterEvent(QDragEnterEvent* event) {

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QEvent>
-#include <QGLWidget>
 #include <QHideEvent>
 #include <QShowEvent>
 
@@ -14,6 +13,7 @@
 #include "widget/trackdroptarget.h"
 #include "widget/wbasewidget.h"
 #include "widget/wcoverartmenu.h"
+#include "widget/wglwidget.h"
 #include "widget/wwidget.h"
 
 class ConfigKey;
@@ -22,7 +22,9 @@ class VisualPlayPosition;
 class VinylControlManager;
 class VSyncThread;
 
-class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityListener,
+class WSpinny : public WGLWidget,
+                public WBaseWidget,
+                public VinylSignalQualityListener,
                 public TrackDropTarget {
     Q_OBJECT
   public:

--- a/src/widget/wvumetergl.h
+++ b/src/widget/wvumetergl.h
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <QGLWidget>
-
 #include "skin/legacy/skincontext.h"
 #include "util/duration.h"
+#include "widget/wglwidget.h"
 #include "widget/wpixmapstore.h"
 #include "widget/wwidget.h"
 
 class VSyncThread;
 
-class WVuMeterGL : public QGLWidget, public WBaseWidget {
+class WVuMeterGL : public WGLWidget, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WVuMeterGL(QWidget* parent = nullptr);
@@ -39,7 +38,7 @@ class WVuMeterGL : public QGLWidget, public WBaseWidget {
     void setPeak(double parameter);
 
     // To make sure we render at least once even when we have no signal
-    bool m_bHasRendered;
+    int m_iRendersPending;
     // To indicate that we rendered so we need to swap
     bool m_bSwapNeeded;
     // Current parameter and peak parameter.

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -40,6 +40,13 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
     void leaveEvent(QEvent* /*unused*/) override;
 
+#ifdef MIXXX_USE_QOPENGL
+    // Handle the event forwarded from the QOpenGLWindow
+    void handleEventFromWindow(QEvent* e) {
+        event(e);
+    }
+#endif
+
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;


### PR DESCRIPTION
This PR makes your QOpenGL branch responsive on Windows (using the new buildenv from https://github.com/mixxxdj/mixxx/pull/11074)
If I now move the hardware cross-fader of my controller fast, the cross-fader in th UI follows without lag.

Please try if this helps also on MacOS.