### PR TITLE
use geometrynode for waveformrendererslipmode and waveformrendererstem

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -72,7 +72,9 @@ bool WaveformRendererEndOfTrack::preprocessInner() {
 
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 
-    const double blinkIntensity = (double)(2 * abs(elapsed - kBlinkingPeriodMillis / 2)) /
+    const double blinkIntensity =
+            static_cast<double>(
+                    2 * std::abs(elapsed - kBlinkingPeriodMillis / 2)) /
             kBlinkingPeriodMillis;
 
     const double remainingTime = m_pTimeRemainingControl->get();

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -1,9 +1,14 @@
 #include "waveform/renderers/allshader/waveformrendererslipmode.h"
 
 #include <QDomNode>
+#include <QVector4D>
 #include <memory>
 
 #include "control/controlproxy.h"
+#include "rendergraph/geometry.h"
+#include "rendergraph/material/rgbamaterial.h"
+#include "rendergraph/vertexupdaters/rgbavertexupdater.h"
+#include "util/colorcomponents.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/wskincolor.h"
@@ -11,106 +16,119 @@
 namespace {
 
 constexpr int kBlinkingPeriodMillis = 1600;
-// Position matrix passed to OpenGL when drawing the shader
-constexpr float positionArray[] = {-1.f, -1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f};
 
 // Used as default outline color in case no value is provided in the theme
-
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-constexpr
-#else
-const
-#endif
-        QColor kDefaultColor = QColor(224, 224, 224);
+constexpr QColor kDefaultColor = QColor(224, 224, 224);
 
 } // anonymous namespace
+
+using namespace rendergraph;
 
 namespace allshader {
 
 WaveformRendererSlipMode::WaveformRendererSlipMode(
         WaveformWidgetRenderer* waveformWidget)
-        : WaveformRenderer(waveformWidget),
+        : ::WaveformRendererAbstract(waveformWidget),
           m_slipBorderTopOutlineSize(10.f),
           m_slipBorderBottomOutlineSize(10.f) {
+    initForRectangles<RGBAMaterial>(0);
+    setUsePreprocess(true);
+}
+
+void WaveformRendererSlipMode::draw(QPainter* painter, QPaintEvent* event) {
+    Q_UNUSED(painter);
+    Q_UNUSED(event);
+    DEBUG_ASSERT(false);
 }
 
 bool WaveformRendererSlipMode::init() {
     m_timer.restart();
 
-    m_pSlipMode = std::make_unique<ControlProxy>(
-            m_waveformRenderer->getGroup(), "slip_enabled");
+    m_pSlipModeControl.reset(new ControlProxy(
+            m_waveformRenderer->getGroup(), "slip_enabled"));
 
     return true;
 }
 
-void WaveformRendererSlipMode::setup(const QDomNode& node, const SkinContext& context) {
-    const QString slipModeOutlineColorName = context.selectString(node, "SlipBorderOutlineColor");
+void WaveformRendererSlipMode::setup(const QDomNode& node, const SkinContext& skinContext) {
+    const QString slipModeOutlineColorName =
+            skinContext.selectString(node, "SlipBorderOutlineColor");
     if (!slipModeOutlineColorName.isNull()) {
         m_color = WSkinColor::getCorrectColor(QColor(slipModeOutlineColorName));
     } else {
         m_color = kDefaultColor;
     }
-    const float slipBorderTopOutlineSize = context.selectFloat(
+    const float slipBorderTopOutlineSize = skinContext.selectFloat(
             node, "SlipBorderTopOutlineSize", m_slipBorderTopOutlineSize);
     if (slipBorderTopOutlineSize >= 0) {
         m_slipBorderTopOutlineSize = slipBorderTopOutlineSize;
     }
-    const float slipBorderBottomOutlineSize = context.selectFloat(
+    const float slipBorderBottomOutlineSize = skinContext.selectFloat(
             node, "SlipBorderBottomOutlineSize", m_slipBorderBottomOutlineSize);
     if (slipBorderBottomOutlineSize >= 0) {
         m_slipBorderBottomOutlineSize = slipBorderBottomOutlineSize;
     }
 }
 
-void WaveformRendererSlipMode::initializeGL() {
-    m_shader.init();
+void WaveformRendererSlipMode::preprocess() {
+    if (!preprocessInner()) {
+        geometry().allocate(0);
+        markDirtyGeometry();
+    }
 }
 
-void WaveformRendererSlipMode::paintGL() {
-    if (!m_pSlipMode->toBool() || !m_waveformRenderer->isSlipActive()) {
-        return;
+bool WaveformRendererSlipMode::preprocessInner() {
+    if (!m_pSlipModeControl->toBool() || !m_waveformRenderer->isSlipActive()) {
+        return false;
     }
 
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 
-    const double blinkIntensity =
-            static_cast<double>(2 * abs(elapsed - kBlinkingPeriodMillis / 2)) /
+    const float blinkIntensity =
+            static_cast<float>(
+                    2 * std::abs(elapsed - kBlinkingPeriodMillis / 2)) /
             kBlinkingPeriodMillis;
 
-    const double alpha = 0.25 + 0.5 * blinkIntensity;
+    const float alpha = std::clamp(0.25 + 0.5 * blinkIntensity, 0.0, 1.0);
 
-    if (alpha != 0.0) {
-        QColor color = m_color;
-        color.setAlphaF(static_cast<float>(alpha));
+    const float posx1 = 0.f;
+    const float posx2 = m_waveformRenderer->getLength();
+    const float posy1 = 0.f;
+    const float posy2 = m_waveformRenderer->getBreadth() / 2.f;
 
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    const float sideBorderOutlineSide = m_slipBorderTopOutlineSize;
 
-        const int colorLocation = m_shader.colorLocation();
-        const int borderLocation = m_shader.boarderLocation();
-        const int positionLocation = m_shader.positionLocation();
-        const int gradientLocation = m_shader.dimensionLocation();
+    const QVector4D bgColor{0.f, 0.f, 0.f, 1.f};
+    const QVector4D borderColor{m_color.redF(), m_color.greenF(), m_color.blueF(), alpha};
+    const QVector4D borderColor0{m_color.redF(), m_color.greenF(), m_color.blueF(), 0.f};
 
-        m_shader.bind();
-        m_shader.enableAttributeArray(positionLocation);
+    const int numVerticesPerLine = 6;            // 2 triangles
+    geometry().allocate(numVerticesPerLine * 5); // border on 4 sides + bgColor filler in center
 
-        m_shader.setUniformValue(colorLocation, color);
-        m_shader.setUniformValue(borderLocation,
-                m_slipBorderTopOutlineSize,
-                m_slipBorderBottomOutlineSize);
+    RGBAVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
 
-        m_shader.setAttributeArray(
-                positionLocation, GL_FLOAT, positionArray, 2);
+    vertexUpdater.addRectangle(
+            {posx1, posy1},
+            {posx2, posy2},
+            bgColor);
 
-        m_shader.setUniformValue(gradientLocation,
-                static_cast<float>(m_waveformRenderer->getLength()) / 2,
-                static_cast<float>(m_waveformRenderer->getBreadth()) / 2);
+    vertexUpdater.addRectangle(
+            {posx1, posy1}, {posx2, posy1 + m_slipBorderTopOutlineSize}, borderColor);
+    vertexUpdater.addRectangle({posx1, posy1 + m_slipBorderTopOutlineSize},
+            {posx1 + sideBorderOutlineSide,
+                    posy2},
+            borderColor);
+    vertexUpdater.addRectangle({posx2 - sideBorderOutlineSide, posy1 + m_slipBorderTopOutlineSize},
+            {posx2, posy2},
+            borderColor);
+    vertexUpdater.addRectangleVGradient({posx1, posy2},
+            {posx2, posy2 + m_slipBorderBottomOutlineSize},
+            borderColor,
+            borderColor0);
+    markDirtyGeometry();
+    markDirtyMaterial();
 
-        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-        m_shader.disableAttributeArray(positionLocation);
-        m_shader.release();
-    }
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.h
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.h
@@ -3,11 +3,11 @@
 #include <QColor>
 #include <memory>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/slipmodeshader.h"
+#include "rendergraph/geometrynode.h"
+#include "rendergraph/opacitynode.h"
 #include "util/class.h"
 #include "util/performancetimer.h"
-#include "waveform/renderers/allshader/waveformrenderer.h"
+#include "waveform/renderers/waveformrendererabstract.h"
 
 class ControlProxy;
 class QDomNode;
@@ -18,28 +18,32 @@ class WaveformRendererSlipMode;
 }
 
 class allshader::WaveformRendererSlipMode final
-        : public allshader::WaveformRenderer,
-          public rendergraph::OpenGLNode {
+        : public ::WaveformRendererAbstract,
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererSlipMode(
             WaveformWidgetRenderer* waveformWidget);
+
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
 
     void setup(const QDomNode& node, const SkinContext& skinContext) override;
 
     bool init() override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    // Virtual for rendergraph::Node
+    void preprocess() override;
 
   private:
-    mixxx::SlipModeShader m_shader;
-    std::unique_ptr<ControlProxy> m_pSlipMode;
+    std::unique_ptr<ControlProxy> m_pSlipModeControl;
 
     float m_slipBorderTopOutlineSize;
     float m_slipBorderBottomOutlineSize;
 
     QColor m_color;
     PerformanceTimer m_timer;
+
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererSlipMode);
 };

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -5,12 +5,19 @@
 #include <QOpenGLTexture>
 
 #include "engine/engine.h"
+#include "rendergraph/material/rgbamaterial.h"
+#include "rendergraph/vertexupdaters/rgbavertexupdater.h"
 #include "track/track.h"
+#include "util/assert.h"
 #include "util/math.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
-#include "waveform/renderers/allshader/rgbdata.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
+
+using namespace rendergraph;
+
+namespace {
+constexpr int kMaxSupportedStems = 4;
+} // anonymous namespace
 
 namespace allshader {
 
@@ -19,66 +26,83 @@ WaveformRendererStem::WaveformRendererStem(
         ::WaveformRendererAbstract::PositionSource type)
         : WaveformRendererSignalBase(waveformWidget),
           m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
+    initForRectangles<RGBAMaterial>(0);
+    setUsePreprocess(true);
 }
 
 void WaveformRendererStem::onSetup(const QDomNode& node) {
     Q_UNUSED(node);
 }
 
-void WaveformRendererStem::initializeGL() {
-    m_shader.init();
-    m_textureShader.init();
-    auto group = m_pEQEnabled->getKey().group;
-    for (int stemIdx = 1; stemIdx <= mixxx::kMaxSupportedStems; stemIdx++) {
+bool WaveformRendererStem::init() {
+    auto group = m_waveformRenderer->getGroup();
+    VERIFY_OR_DEBUG_ASSERT(!group.isEmpty()) {
+        return false;
+    }
+    for (int stemIdx = 1; stemIdx <= kMaxSupportedStems; stemIdx++) {
         DEBUG_ASSERT(group.endsWith("]"));
         QString stemGroup = QStringLiteral("%1Stem%2]")
                                     .arg(group.left(group.size() - 1),
                                             QString::number(stemIdx));
         m_pStemGain.emplace_back(
-                std::make_unique<ControlProxy>(stemGroup,
+                std::make_unique<PollingControlProxy>(stemGroup,
                         QStringLiteral("volume")));
-        m_pStemMute.emplace_back(std::make_unique<ControlProxy>(
+        m_pStemMute.emplace_back(std::make_unique<PollingControlProxy>(
                 stemGroup, QStringLiteral("mute")));
+    }
+    return true;
+}
+
+void WaveformRendererStem::preprocess() {
+    if (!preprocessInner()) {
+        if (geometry().vertexCount() != 0) {
+            geometry().allocate(0);
+            markDirtyGeometry();
+        }
     }
 }
 
-void WaveformRendererStem::paintGL() {
+bool WaveformRendererStem::preprocessInner() {
     TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+
     if (!pTrack || (m_isSlipRenderer && !m_waveformRenderer->isSlipActive())) {
-        return;
+        return false;
     }
 
     auto stemInfo = pTrack->getStemInfo();
     // If this track isn't a stem track, skip the rendering
     if (stemInfo.isEmpty()) {
-        return;
+        return false;
     }
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
                                          : ::WaveformRendererAbstract::Play;
 
     ConstWaveformPointer waveform = pTrack->getWaveform();
     if (waveform.isNull()) {
-        return;
+        return false;
     }
 
     const int dataSize = waveform->getDataSize();
     if (dataSize <= 1) {
-        return;
+        return false;
     }
 
     const WaveformData* data = waveform->data();
     if (data == nullptr) {
-        return;
+        return false;
     }
     // If this waveform doesn't contain stem data, skip the rendering
     if (!waveform->hasStem()) {
-        return;
+        return false;
     }
 
     uint selectedStems = m_waveformRenderer->getSelectedStems();
 
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const int length = static_cast<int>(m_waveformRenderer->getLength());
+    const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const float invDevicePixelRatio = 1.f / devicePixelRatio;
+    const float halfPixelSize = 0.5 / devicePixelRatio;
 
     // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
@@ -89,14 +113,14 @@ void WaveformRendererStem::paintGL() {
 
     // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(pixelLength);
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0);
     // applyCompensation = true, as we scale to match filtered.all
     getGains(&allGain, false, nullptr, nullptr, nullptr);
 
-    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
+    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;
 
     const float heightFactor = allGain * halfBreadth / m_maxValue;
@@ -107,22 +131,22 @@ void WaveformRendererStem::paintGL() {
 
     const int numVerticesPerLine = 6; // 2 triangles
 
-    const int reserved = numVerticesPerLine * (8 * length + 1);
+    const int reserved = numVerticesPerLine * (8 * pixelLength + 1);
 
-    m_vertices.clear();
-    m_vertices.reserve(reserved);
-    m_colors.clear();
-    m_colors.reserve(reserved);
+    geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
+    geometry().allocate(reserved);
+    markDirtyGeometry();
 
-    m_vertices.addRectangle(0.f,
-            halfBreadth - 0.5f * devicePixelRatio,
-            static_cast<float>(length),
-            m_isSlipRenderer ? halfBreadth : halfBreadth + 0.5f * devicePixelRatio);
-    m_colors.addForRectangle(0.f, 0.f, 0.f, 0.f);
+    RGBAVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
+    vertexUpdater.addRectangle({0.f,
+                                       halfBreadth - 0.5f},
+            {static_cast<float>(length),
+                    m_isSlipRenderer ? halfBreadth : halfBreadth + 0.5f},
+            {0.f, 0.f, 0.f, 0.f});
 
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
-    for (int visualIdx = 0; visualIdx < length; ++visualIdx) {
+    for (int visualIdx = 0; visualIdx < pixelLength; ++visualIdx) {
         for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; stemIdx++) {
             // Stem is drawn twice with different opacity level, this allow to
             // see the maximum signal by transparency
@@ -139,7 +163,7 @@ void WaveformRendererStem::paintGL() {
                 const int visualIndexStop =
                         std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
-                const float fVisualIdx = static_cast<float>(visualIdx);
+                const float fVisualIdx = static_cast<float>(visualIdx) * invDevicePixelRatio;
 
                 // Find the max values for current eq in the waveform data.
                 // - Max of left and right
@@ -166,43 +190,23 @@ void WaveformRendererStem::paintGL() {
                 }
 
                 // Lines are thin rectangles
-                // shawdow
-                m_vertices.addRectangle(fVisualIdx - 0.5f,
-                        halfBreadth - heightFactor * max,
-                        fVisualIdx + 0.5f,
-                        m_isSlipRenderer ? halfBreadth : halfBreadth + heightFactor * max);
-
-                m_colors.addForRectangle(color_r, color_g, color_b, color_a);
+                // shadow
+                vertexUpdater.addRectangle({fVisualIdx - halfPixelSize,
+                                                   halfBreadth - heightFactor * max},
+                        {fVisualIdx + halfPixelSize,
+                                m_isSlipRenderer ? halfBreadth : halfBreadth + heightFactor * max},
+                        {color_r, color_g, color_b, color_a});
             }
         }
+
         xVisualFrame += visualIncrementPerPixel;
     }
 
-    DEBUG_ASSERT(reserved == m_vertices.size());
-    DEBUG_ASSERT(reserved == m_colors.size());
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
 
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
+    markDirtyMaterial();
 
-    const int matrixLocation = m_shader.matrixLocation();
-    const int positionLocation = m_shader.positionLocation();
-    const int colorLocation = m_shader.colorLocation();
-
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-    m_shader.enableAttributeArray(colorLocation);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, m_vertices.constData(), 2);
-    m_shader.setAttributeArray(
-            colorLocation, GL_FLOAT, m_colors.constData(), 4);
-
-    glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.disableAttributeArray(colorLocation);
-    m_shader.release();
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererstem.h
+++ b/src/waveform/renderers/allshader/waveformrendererstem.h
@@ -2,12 +2,9 @@
 
 #include <vector>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/rgbashader.h"
-#include "shaders/textureshader.h"
+#include "control/pollingcontrolproxy.h"
+#include "rendergraph/geometrynode.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/rgbadata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 class QOpenGLTexture;
@@ -18,30 +15,31 @@ class WaveformRendererStem;
 
 class allshader::WaveformRendererStem final
         : public allshader::WaveformRendererSignalBase,
-          public rendergraph::OpenGLNode {
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererStem(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
                     ::WaveformRendererAbstract::Play);
 
-    // override ::WaveformRendererSignalBase
+    // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    bool init() override;
+
+    bool supportsSlip() const override {
+        return true;
+    }
+
+    // Virtuals for rendergraph::Node
+    void preprocess() override;
 
   private:
-    mixxx::RGBAShader m_shader;
-    mixxx::TextureShader m_textureShader;
-    VertexData m_vertices;
-    RGBAData m_colors;
-
     bool m_isSlipRenderer;
 
-    std::vector<std::unique_ptr<ControlProxy>> m_pStemGain;
-    std::vector<std::unique_ptr<ControlProxy>> m_pStemMute;
+    std::vector<std::unique_ptr<PollingControlProxy>> m_pStemGain;
+    std::vector<std::unique_ptr<PollingControlProxy>> m_pStemMute;
 
-    void drawTexture(float x, float y, QOpenGLTexture* texture);
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererStem);
 };


### PR DESCRIPTION
I have split the rendergraph PR https://github.com/mixxxdj/mixxx/pull/13599 into muliple PRs

https://github.com/m0dB/mixxx/pull/new/rg-rendergraph
https://github.com/m0dB/mixxx/pull/new/rg-use-opengl-node
https://github.com/m0dB/mixxx/pull/new/rg-shaders
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendererendoftrack
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendererpreroll
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-markrange-beat
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendermark 
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-signals
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-stem-slip
https://github.com/m0dB/mixxx/pull/new/rg-cleanup

These should be merged in order. I set the base of each PR to the previous PR. Once the previous PR has been merged, it should be retargeted to main.