### PR TITLE
use geometrynodes for waveformrendermark

### DIFF
--- a/src/waveform/renderers/allshader/digitsrenderer.cpp
+++ b/src/waveform/renderers/allshader/digitsrenderer.cpp
@@ -5,16 +5,19 @@
 #include <QGraphicsBlurEffect>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsScene>
-#include <QOpenGLTexture>
 #include <QPainter>
 #include <QPainterPath>
 #include <cmath>
 
 #include "./util/assert.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "rendergraph/context.h"
+#include "rendergraph/geometry.h"
+#include "rendergraph/material/texturematerial.h"
+#include "rendergraph/vertexupdaters/texturedvertexupdater.h"
 
 // Render digits using a texture (generated) with digits with blurred dark outline
+
+using namespace rendergraph;
 
 namespace {
 
@@ -56,23 +59,22 @@ static_assert(checkCharToIndex());
 
 } // namespace
 
-allshader::DigitsRenderer::~DigitsRenderer() = default;
-
-void allshader::DigitsRenderer::init() {
-    initializeOpenGLFunctions();
-    m_shader.init();
+allshader::DigitsRenderNode::DigitsRenderNode() {
+    setGeometry(std::make_unique<Geometry>(TextureMaterial::attributes(), 0));
+    setMaterial(std::make_unique<TextureMaterial>());
+    geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
 }
 
-float allshader::DigitsRenderer::height() const {
+allshader::DigitsRenderNode::~DigitsRenderNode() = default;
+
+float allshader::DigitsRenderNode::height() const {
     return m_height;
 }
 
-void allshader::DigitsRenderer::updateTexture(
-        float fontPointSize, float maxHeight, float devicePixelRatio) {
-    if (std::lround(maxHeight * devicePixelRatio) <= 0) {
-        return;
-    }
-
+void allshader::DigitsRenderNode::updateTexture(rendergraph::Context* pContext,
+        float fontPointSize,
+        float maxHeight,
+        float devicePixelRatio) {
     if (fontPointSize == m_fontPointSize && maxHeight == m_maxHeight) {
         return;
     }
@@ -94,7 +96,6 @@ void allshader::DigitsRenderer::updateTexture(
     QFont font;
     QFontMetricsF metrics{font};
     font.setFamily("Open Sans");
-    qreal totalTextWidth;
     qreal maxTextHeight;
     bool retry = false;
     do {
@@ -111,14 +112,12 @@ void allshader::DigitsRenderer::updateTexture(
 
         metrics = QFontMetricsF{font};
 
-        totalTextWidth = 0;
         maxTextHeight = 0;
 
         for (int i = 0; i < NUM_CHARS; i++) {
             const QString text(indexToChar(i));
             const auto rect = metrics.tightBoundingRect(text);
             maxTextHeight = std::max(maxTextHeight, rect.height());
-            totalTextWidth += metrics.horizontalAdvance(text);
         }
         if (m_adjustedFontPointSize == 0.f && !retry && maxTextHeight > maxHeightWithoutSpace) {
             // We need to adjust the font size to fit in the maxHeight.
@@ -135,11 +134,25 @@ void allshader::DigitsRenderer::updateTexture(
 
     m_height = static_cast<float>(std::ceil(maxTextHeight) + space * 2 + 1);
 
-    // Space around the digits
-    totalTextWidth += (space * 2 + 1) * NUM_CHARS;
-    totalTextWidth = std::ceil(totalTextWidth);
-
     const qreal y = maxTextHeight + space - 0.5;
+
+    qreal totalTextWidth{};
+    std::array<qreal, NUM_CHARS> xs;
+    for (int i = 0; i < NUM_CHARS; i++) {
+        const QString text(indexToChar(i));
+        xs[i] = totalTextWidth;
+        qreal w = std::round(metrics.horizontalAdvance(text) *
+                          devicePixelRatio) /
+                        devicePixelRatio +
+                space + space + 1.0;
+        totalTextWidth += w;
+        m_width[i] = static_cast<float>(w);
+    }
+    for (int i = 0; i < NUM_CHARS; i++) {
+        // position and width of character at index i in the texture, normalized
+        m_offset[i] = static_cast<float>(xs[i] / totalTextWidth);
+    }
+    m_offset[NUM_CHARS] = 1.f;
 
     QImage image(std::lround(totalTextWidth * devicePixelRatio),
             std::lround(m_height * devicePixelRatio),
@@ -157,12 +170,10 @@ void allshader::DigitsRenderer::updateTexture(
         painter.setBrush(QColor(0, 0, 0, OUTLINE_ALPHA));
         painter.setPen(pen);
         painter.setFont(font);
-        qreal x = 0;
         QPainterPath path;
         for (int i = 0; i < NUM_CHARS; i++) {
             const QString text(indexToChar(i));
-            path.addText(QPointF(x + space + 0.5, y), font, text);
-            x += metrics.horizontalAdvance(text) + space + space + 1;
+            path.addText(QPointF(xs[i] + space + 0.5, y), font, text);
         }
         painter.drawPath(path);
     }
@@ -173,12 +184,12 @@ void allshader::DigitsRenderer::updateTexture(
         blur->setBlurRadius(static_cast<qreal>(m_penWidth) / 3);
 
         QGraphicsScene scene;
-        auto item = std::make_unique<QGraphicsPixmapItem>();
-        item->setPixmap(QPixmap::fromImage(image));
-        item->setGraphicsEffect(blur.release());
+        QGraphicsPixmapItem item;
+        item.setPixmap(QPixmap::fromImage(image));
+        item.setGraphicsEffect(blur.release());
         image.fill(Qt::transparent);
         QPainter painter(&image);
-        scene.addItem(item.release());
+        scene.addItem(&item);
         scene.render(&painter, QRectF(), QRectF(0, 0, image.width(), image.height()));
     }
 
@@ -191,37 +202,61 @@ void allshader::DigitsRenderer::updateTexture(
         painter.setPen(Qt::white);
         painter.setBrush(Qt::white);
 
-        qreal x = 0;
         QPainterPath path;
         for (int i = 0; i < NUM_CHARS; i++) {
             const QString text(indexToChar(i));
-            path.addText(QPointF(x + space + 0.5, y), font, text);
-            // position and width of character at index i in the texture
-            m_offset[i] = static_cast<float>(x / totalTextWidth);
-            const auto xp = x;
-            x += metrics.horizontalAdvance(text) + space + space + 1;
-            m_width[i] = static_cast<float>(x - xp);
+            path.addText(QPointF(xs[i] + space + 0.5, y), font, text);
         }
         painter.drawPath(path);
-        m_offset[NUM_CHARS] = 1.f;
     }
 
-    m_texture.setData(image);
+    dynamic_cast<TextureMaterial&>(material())
+            .setTexture(std::make_unique<Texture>(pContext, image));
 }
 
-float allshader::DigitsRenderer::draw(const QMatrix4x4& matrix,
+void allshader::DigitsRenderNode::update(
+        float x,
+        float y,
+        bool multiLine,
+        const QString& s1,
+        const QString& s2) {
+    const int numVerticesPerRectangle = 6;
+    const int reserved = (s1.length() + s2.length()) * numVerticesPerRectangle;
+    geometry().allocate(reserved);
+    TexturedVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::TexturedPoint2D>()};
+
+    const float ch = height();
+    if (!s1.isEmpty()) {
+        const auto w = addVertices(vertexUpdater,
+                x,
+                y,
+                s1);
+        if (multiLine) {
+            y += ch;
+        } else {
+            x += w + ch * 0.75f;
+        }
+    }
+    if (!s2.isEmpty()) {
+        addVertices(vertexUpdater,
+                x,
+                y,
+                s2);
+    }
+
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
+}
+
+void allshader::DigitsRenderNode::clear() {
+    geometry().allocate(0);
+}
+
+float allshader::DigitsRenderNode::addVertices(TexturedVertexUpdater& vertexUpdater,
         float x,
         float y,
         const QString& s) {
-    const int n = s.length();
     const float x0 = x;
     const float space = static_cast<float>(m_penWidth) / 2;
-
-    VertexData posVertices;
-    VertexData texVertices;
-
-    posVertices.reserve(n * 6); // two triangles per character
-    texVertices.reserve(n * 6);
 
     for (QChar c : s) {
         if (x != x0) {
@@ -229,41 +264,12 @@ float allshader::DigitsRenderer::draw(const QMatrix4x4& matrix,
         }
         int index = charToIndex(c);
 
-        texVertices.addRectangle(m_offset[index], 0.f, m_offset[index + 1], 1.f);
-        posVertices.addRectangle(x,
-                y,
-                x + m_width[index],
-                y + height());
+        vertexUpdater.addRectangle({x, y},
+                {x + m_width[index], y + height()},
+                {m_offset[index], 0.f},
+                {m_offset[index + 1], 1.f});
         x += m_width[index];
     }
-
-    m_shader.bind();
-
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int textureLocation = m_shader.uniformLocation("texture");
-    const int positionLocation = m_shader.attributeLocation("position");
-    const int texcoordLocation = m_shader.attributeLocation("texcoord");
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-
-    m_shader.enableAttributeArray(positionLocation);
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, posVertices.constData(), 2);
-    m_shader.enableAttributeArray(texcoordLocation);
-    m_shader.setAttributeArray(
-            texcoordLocation, GL_FLOAT, texVertices.constData(), 2);
-
-    m_shader.setUniformValue(textureLocation, 0);
-
-    m_texture.bind();
-
-    glDrawArrays(GL_TRIANGLES, 0, posVertices.size());
-
-    m_texture.release();
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.disableAttributeArray(texcoordLocation);
-    m_shader.release();
 
     return x - x0;
 }

--- a/src/waveform/renderers/allshader/digitsrenderer.h
+++ b/src/waveform/renderers/allshader/digitsrenderer.h
@@ -1,30 +1,44 @@
 #pragma once
 
-#include <QOpenGLFunctions>
+#include "rendergraph/context.h"
+#include "rendergraph/geometrynode.h"
+#include "util/class.h"
 
-#include "shaders/textureshader.h"
-#include "util/opengltexture2d.h"
+namespace rendergraph {
+class TexturedVertexUpdater;
+} // namespace rendergraph
 
 namespace allshader {
-class DigitsRenderer;
-}
+class DigitsRenderNode;
+} // namespace allshader
 
-class allshader::DigitsRenderer : public QOpenGLFunctions {
+class allshader::DigitsRenderNode : public rendergraph::GeometryNode {
   public:
-    DigitsRenderer() = default;
-    ~DigitsRenderer();
+    DigitsRenderNode();
+    ~DigitsRenderNode();
 
-    void init();
-    void updateTexture(float fontPointSize, float maxHeight, float devicePixelRatio);
-    float draw(const QMatrix4x4& matrix,
+    void updateTexture(rendergraph::Context* pContext,
+            float fontPointSize,
+            float maxHeight,
+            float devicePixelRatio);
+
+    void update(
             float x,
             float y,
-            const QString& s);
+            bool multiLine,
+            const QString& s1,
+            const QString& s2);
+
+    void clear();
+
     float height() const;
 
   private:
-    mixxx::TextureShader m_shader;
-    OpenGLTexture2D m_texture;
+    float addVertices(rendergraph::TexturedVertexUpdater& vertexUpdater,
+            float x,
+            float y,
+            const QString& s);
+
     int m_penWidth;
     float m_offset[13];
     float m_width[12];
@@ -32,5 +46,5 @@ class allshader::DigitsRenderer : public QOpenGLFunctions {
     float m_height{};
     float m_maxHeight{};
     float m_adjustedFontPointSize{};
-    DISALLOW_COPY_AND_ASSIGN(DigitsRenderer);
+    DISALLOW_COPY_AND_ASSIGN(DigitsRenderNode);
 };

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -1,15 +1,22 @@
 #include "waveform/renderers/allshader/waveformrendermark.h"
 
-#include <QOpenGLTexture>
 #include <QPainterPath>
 
+#include "rendergraph/context.h"
+#include "rendergraph/geometry.h"
+#include "rendergraph/geometrynode.h"
+#include "rendergraph/material/rgbamaterial.h"
+#include "rendergraph/material/texturematerial.h"
+#include "rendergraph/texture.h"
+#include "rendergraph/vertexupdaters/rgbavertexupdater.h"
+#include "rendergraph/vertexupdaters/texturedvertexupdater.h"
 #include "track/track.h"
 #include "util/colorcomponents.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
-#include "waveform/renderers/allshader/rgbadata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/digitsrenderer.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveformwidgetfactory.h"
+
+using namespace rendergraph;
 
 // On the use of QPainter:
 //
@@ -20,18 +27,104 @@
 // only to draw on a QImage. This is only done once when needed and the images are
 // then used as textures to be drawn with a GLSL shader.
 
-class TextureGraphics : public WaveformMark::Graphics {
+namespace {
+
+auto makeRoundToPixel(float devicePixelRatio) {
+    return [devicePixelRatio](float pos) {
+        return std::round(pos * devicePixelRatio) / devicePixelRatio;
+    };
+}
+
+class WaveformMarkNode : public rendergraph::GeometryNode {
   public:
-    TextureGraphics(const QImage& image) {
-        m_texture.setData(image);
+    WaveformMark* m_pOwner{};
+
+    WaveformMarkNode(WaveformMark* pOwner, rendergraph::Context* pContext, const QImage& image)
+            : m_pOwner(pOwner) {
+        initForRectangles<TextureMaterial>(1);
+        updateTexture(pContext, image);
     }
-    QOpenGLTexture* texture() {
-        return &m_texture;
+    void updateTexture(rendergraph::Context* pContext, const QImage& image) {
+        dynamic_cast<TextureMaterial&>(material())
+                .setTexture(std::make_unique<Texture>(pContext, image));
+        m_textureWidth = image.width();
+        m_textureHeight = image.height();
+    }
+    void update(float x, float y, float devicePixelRatio) {
+        [[maybe_unused]] const float epsilon = 1e-6f;
+        DEBUG_ASSERT(std::abs(x - RoundToPixel(devicePixelRatio)(x)) < epsilon);
+        DEBUG_ASSERT(std::abs(y - RoundToPixel(devicePixelRatio)(y)) < epsilon);
+        TexturedVertexUpdater vertexUpdater{
+                geometry().vertexDataAs<Geometry::TexturedPoint2D>()};
+        vertexUpdater.addRectangle({x, y},
+                {x + m_textureWidth / devicePixelRatio,
+                        y + m_textureHeight / devicePixelRatio},
+                {0.f, 0.f},
+                {1.f, 1.f});
+    }
+    float textureWidth() const {
+        return m_textureWidth;
+    }
+    float textureHeight() const {
+        return m_textureHeight;
+    }
+
+  public:
+    float m_textureWidth{};
+    float m_textureHeight{};
+};
+
+class WaveformMarkNodeGraphics : public WaveformMark::Graphics {
+  public:
+    WaveformMarkNodeGraphics(WaveformMark* pOwner,
+            rendergraph::Context* pContext,
+            const QImage& image)
+            : m_pNode(std::make_unique<WaveformMarkNode>(
+                      pOwner, pContext, image)) {
+    }
+    void updateTexture(rendergraph::Context* pContext, const QImage& image) {
+        waveformMarkNode()->updateTexture(pContext, image);
+    }
+    void update(float x, float y, float devicePixelRatio) {
+        waveformMarkNode()->update(x, y, devicePixelRatio);
+    }
+    float textureWidth() const {
+        return waveformMarkNode()->textureWidth();
+    }
+    float textureHeight() const {
+        return waveformMarkNode()->textureHeight();
+    }
+    void attachNode(std::unique_ptr<rendergraph::BaseNode> pNode) {
+        DEBUG_ASSERT(!m_pNode);
+        m_pNode = std::move(pNode);
+    }
+    std::unique_ptr<rendergraph::BaseNode> detachNode() {
+        return std::move(m_pNode);
     }
 
   private:
-    OpenGLTexture2D m_texture;
+    WaveformMarkNode* waveformMarkNode() const {
+        DEBUG_ASSERT(m_pNode);
+        return static_cast<WaveformMarkNode*>(m_pNode.get());
+    }
+
+    std::unique_ptr<rendergraph::BaseNode> m_pNode;
 };
+
+constexpr float kPlayPosWidth{11.f};
+constexpr float kPlayPosOffset{-(kPlayPosWidth - 1.f) / 2.f};
+
+QString timeSecToString(double timeSec) {
+    int hundredths = std::lround(timeSec * 100.0);
+    int seconds = hundredths / 100;
+    hundredths -= seconds * 100;
+    int minutes = seconds / 60;
+    seconds -= minutes * 60;
+
+    return QString::asprintf("%d:%02d.%02d", minutes, seconds, hundredths);
+}
+
+} // namespace
 
 // Both allshader::WaveformRenderMark and the non-GL ::WaveformRenderMark derive
 // from WaveformRenderMarkBase. The base-class takes care of updating the marks
@@ -45,19 +138,6 @@ class TextureGraphics : public WaveformMark::Graphics {
 // The boolean argument for the WaveformRenderMarkBase constructor indicates
 // that updateMarkImages should not be called immediately.
 
-namespace {
-QString timeSecToString(double timeSec) {
-    int hundredths = std::lround(timeSec * 100.0);
-    int seconds = hundredths / 100;
-    hundredths -= seconds * 100;
-    int minutes = seconds / 60;
-    seconds -= minutes * 60;
-
-    return QString::asprintf("%d:%02d.%02d", minutes, seconds, hundredths);
-}
-
-} // namespace
-
 allshader::WaveformRenderMark::WaveformRenderMark(
         WaveformWidgetRenderer* waveformWidget,
         ::WaveformRendererAbstract::PositionSource type)
@@ -65,13 +145,33 @@ allshader::WaveformRenderMark::WaveformRenderMark(
           m_beatsUntilMark(0),
           m_timeUntilMark(0.0),
           m_pTimeRemainingControl(nullptr),
-          m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
-}
+          m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip),
+          m_playPosHeight(0.f),
+          m_playPosDevicePixelRatio(0.f) {
+    {
+        auto pNode = std::make_unique<Node>();
+        m_pRangeNodesParent = pNode.get();
+        appendChildNode(std::move(pNode));
+    }
 
-bool allshader::WaveformRenderMark::init() {
-    m_pTimeRemainingControl = std::make_unique<ControlProxy>(
-            m_waveformRenderer->getGroup(), "time_remaining");
-    return true;
+    {
+        auto pNode = std::make_unique<Node>();
+        m_pMarkNodesParent = pNode.get();
+        appendChildNode(std::move(pNode));
+    }
+
+    {
+        auto pNode = std::make_unique<DigitsRenderNode>();
+        m_pDigitsRenderNode = pNode.get();
+        appendChildNode(std::move(pNode));
+    }
+
+    {
+        auto pNode = std::make_unique<GeometryNode>();
+        m_pPlayPosNode = pNode.get();
+        m_pPlayPosNode->initForRectangles<TextureMaterial>(1);
+        appendChildNode(std::move(pNode));
+    }
 }
 
 void allshader::WaveformRenderMark::draw(QPainter* painter, QPaintEvent* event) {
@@ -80,74 +180,16 @@ void allshader::WaveformRenderMark::draw(QPainter* painter, QPaintEvent* event) 
     DEBUG_ASSERT(false);
 }
 
-void allshader::WaveformRenderMark::initializeGL() {
-    m_digitsRenderer.init();
-    m_rgbaShader.init();
-    m_textureShader.init();
-
-    // Will create textures so requires OpenGL context
-    updateMarkImages();
-    updatePlayPosMarkTexture();
-    const auto untilMarkTextPointSize =
-            WaveformWidgetFactory::instance()->getUntilMarkTextPointSize();
-    const auto untilMarkTextHeightLimit =
-            WaveformWidgetFactory::instance()
-                    ->getUntilMarkTextHeightLimit(); // proportion of waveform
-                                                     // height
-    const auto untilMarkMaxHeightForText = getMaxHeightForText(untilMarkTextHeightLimit);
-
-    m_digitsRenderer.updateTexture(untilMarkTextPointSize,
-            untilMarkMaxHeightForText,
-            m_waveformRenderer->getDevicePixelRatio());
+bool allshader::WaveformRenderMark::init() {
+    m_pTimeRemainingControl = std::make_unique<ControlProxy>(
+            m_waveformRenderer->getGroup(), "time_remaining");
+    ::WaveformRenderMarkBase::init();
+    return true;
 }
 
-void allshader::WaveformRenderMark::drawTexture(
-        const QMatrix4x4& matrix, float x, float y, QOpenGLTexture* texture) {
-    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    const float texx1 = 0.f;
-    const float texy1 = 0.f;
-    const float texx2 = 1.f;
-    const float texy2 = 1.f;
-
-    const float posx1 = x;
-    const float posx2 = x + static_cast<float>(texture->width() / devicePixelRatio);
-    const float posy1 = y;
-    const float posy2 = y + static_cast<float>(texture->height() / devicePixelRatio);
-
-    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
-    const float texarray[] = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
-
-    m_textureShader.bind();
-
-    const int matrixLocation = m_textureShader.uniformLocation("matrix");
-    const int textureLocation = m_textureShader.uniformLocation("texture");
-    const int positionLocation = m_textureShader.attributeLocation("position");
-    const int texcoordLocation = m_textureShader.attributeLocation("texcoord");
-
-    m_textureShader.setUniformValue(matrixLocation, matrix);
-
-    m_textureShader.enableAttributeArray(positionLocation);
-    m_textureShader.setAttributeArray(
-            positionLocation, GL_FLOAT, posarray, 2);
-    m_textureShader.enableAttributeArray(texcoordLocation);
-    m_textureShader.setAttributeArray(
-            texcoordLocation, GL_FLOAT, texarray, 2);
-
-    m_textureShader.setUniformValue(textureLocation, 0);
-
-    texture->bind();
-
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-    texture->release();
-
-    m_textureShader.disableAttributeArray(positionLocation);
-    m_textureShader.disableAttributeArray(texcoordLocation);
-    m_textureShader.release();
-}
-
-void allshader::WaveformRenderMark::drawMark(
-        const QMatrix4x4& matrix, const QRectF& rect, QColor color) {
+void allshader::WaveformRenderMark::updateRangeNode(GeometryNode* pNode,
+        const QRectF& rect,
+        QColor color) {
     // draw a gradient towards transparency at the upper and lower 25% of the waveform view
 
     const float qh = static_cast<float>(std::floor(rect.height() * 0.25));
@@ -162,41 +204,39 @@ void allshader::WaveformRenderMark::drawMark(
 
     getRgbF(color, &r, &g, &b, &a);
 
-    VertexData vertices;
-    vertices.reserve(12); // 4 triangles
-    vertices.addRectangle(posx1, posy1, posx2, posy2);
-    vertices.addRectangle(posx1, posy4, posx2, posy3);
-
-    RGBAData rgbaData;
-    rgbaData.reserve(12); // 4 triangles
-    rgbaData.addForRectangleGradient(r, g, b, a, r, g, b, 0.f);
-    rgbaData.addForRectangleGradient(r, g, b, a, r, g, b, 0.f);
-
-    m_rgbaShader.bind();
-
-    const int matrixLocation = m_rgbaShader.matrixLocation();
-    const int positionLocation = m_rgbaShader.positionLocation();
-    const int colorLocation = m_rgbaShader.colorLocation();
-
-    m_rgbaShader.setUniformValue(matrixLocation, matrix);
-
-    m_rgbaShader.enableAttributeArray(positionLocation);
-    m_rgbaShader.setAttributeArray(
-            positionLocation, GL_FLOAT, vertices.constData(), 2);
-    m_rgbaShader.enableAttributeArray(colorLocation);
-    m_rgbaShader.setAttributeArray(
-            colorLocation, GL_FLOAT, rgbaData.constData(), 4);
-
-    glDrawArrays(GL_TRIANGLES, 0, vertices.size());
-
-    m_rgbaShader.disableAttributeArray(positionLocation);
-    m_rgbaShader.disableAttributeArray(colorLocation);
-    m_rgbaShader.release();
+    RGBAVertexUpdater vertexUpdater{pNode->geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
+    vertexUpdater.addRectangleVGradient(
+            {posx1, posy1}, {posx2, posy2}, {r, g, b, a}, {r, g, b, 0.f});
+    vertexUpdater.addRectangleVGradient(
+            {posx1, posy4}, {posx2, posy3}, {r, g, b, a}, {r, g, b, 0.f});
 }
 
-void allshader::WaveformRenderMark::paintGL() {
-    if (m_isSlipRenderer && !m_waveformRenderer->isSlipActive()) {
+bool allshader::WaveformRenderMark::isSubtreeBlocked() const {
+    return m_isSlipRenderer && !m_waveformRenderer->isSlipActive();
+}
+
+void allshader::WaveformRenderMark::update() {
+    if (isSubtreeBlocked()) {
         return;
+    }
+
+    // For each WaveformMark we create a GeometryNode with Texture
+    // (in updateMarkImage). Of these GeometryNodes, we append the
+    // the ones that need to be shown on screen as children to
+    // m_pMarkNodesParent (transferring ownership).
+    //
+    // At the beginning of a new frame, we remove all the child nodes
+    // from m_pMarkNodesParent and store each with their mark
+    // (transferring ownership). Later in this function we move the
+    // visible nodes back to m_pMarkNodesParent children.
+    while (auto pChild = m_pMarkNodesParent->firstChild()) {
+        auto pNode = m_pMarkNodesParent->detachChildNode(pChild);
+        WaveformMarkNode* pWaveformMarkNode = static_cast<WaveformMarkNode*>(pNode.get());
+        // Determine its WaveformMark
+        auto pMark = pWaveformMarkNode->m_pOwner;
+        auto pGraphics = static_cast<WaveformMarkNodeGraphics*>(pMark->m_pGraphics.get());
+        // Store the node with the WaveformMark
+        pGraphics->attachNode(std::move(pNode));
     }
 
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
@@ -206,20 +246,24 @@ void allshader::WaveformRenderMark::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     QList<WaveformWidgetRenderer::WaveformMarkOnScreen> marksOnScreen;
 
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    auto roundToPixel = makeRoundToPixel(devicePixelRatio);
 
     for (const auto& pMark : std::as_const(m_marks)) {
         pMark->setBreadth(slipActive ? m_waveformRenderer->getBreadth() / 2
                                      : m_waveformRenderer->getBreadth());
     }
-    // Will create textures so requires OpenGL context
-    updateMarkImages();
 
-    QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
+    updatePlayPosMarkTexture(m_waveformRenderer->getContext());
+
+    // Generate initial node or update its texture if needed for each of
+    // the WaveformMarks (in which case updateMarkImage is called)
+    // (Will create textures so requires OpenGL context)
+    updateMarkImages();
 
     const double playPosition = m_waveformRenderer->getTruePosSample(positionType);
     double nextMarkPosition = std::numeric_limits<double>::max();
+
+    GeometryNode* pRangeChild = static_cast<GeometryNode*>(m_pRangeNodesParent->firstChild());
 
     for (const auto& pMark : std::as_const(m_marks)) {
         if (!pMark->isValid()) {
@@ -232,22 +276,14 @@ void allshader::WaveformRenderMark::paintGL() {
             continue;
         }
 
-        QOpenGLTexture* pTexture =
-                static_cast<TextureGraphics*>(pMark->m_pGraphics.get())
-                        ->texture();
-
-        if (!pTexture) {
+        auto pMarkGraphics = pMark->m_pGraphics.get();
+        auto pMarkNodeGraphics = static_cast<WaveformMarkNodeGraphics*>(pMarkGraphics);
+        if (!pMarkGraphics) // is this even possible?
             continue;
-        }
 
-        const float currentMarkPoint =
-                std::round(
-                        static_cast<float>(
-                                m_waveformRenderer
-                                        ->transformSamplePositionInRendererWorld(
-                                                samplePosition, positionType)) *
-                        devicePixelRatio) /
-                devicePixelRatio;
+        const float currentMarkPos = static_cast<float>(
+                m_waveformRenderer->transformSamplePositionInRendererWorld(
+                        samplePosition, positionType));
         if (pMark->isShowUntilNext() &&
                 samplePosition >= playPosition + 1.0 &&
                 samplePosition < nextMarkPosition) {
@@ -255,46 +291,52 @@ void allshader::WaveformRenderMark::paintGL() {
         }
         const double sampleEndPosition = pMark->getSampleEndPosition();
 
-        // Pixmaps are expected to have the mark stroke at the center,
-        // and preferably have an odd width in order to have the stroke
-        // exactly at the sample position.
-        const float markHalfWidth = pTexture->width() / devicePixelRatio / 2.f;
-        const float drawOffset = currentMarkPoint - markHalfWidth;
+        const float markWidth = pMarkNodeGraphics->textureWidth() / devicePixelRatio;
+        const float drawOffset = currentMarkPos + pMark->getOffset();
 
         bool visible = false;
         // Check if the current point needs to be displayed.
-        if (drawOffset > -markHalfWidth &&
-                drawOffset < m_waveformRenderer->getLength() +
-                                markHalfWidth) {
-            drawTexture(matrix,
-                    drawOffset,
+        if (drawOffset > -markWidth &&
+                drawOffset < m_waveformRenderer->getLength()) {
+            pMarkNodeGraphics->update(
+                    roundToPixel(drawOffset),
                     !m_isSlipRenderer && slipActive
-                            ? m_waveformRenderer->getBreadth() / 2
+                            ? roundToPixel(m_waveformRenderer->getBreadth() / 2.f)
                             : 0,
-                    pTexture);
+                    devicePixelRatio);
+
+            // transfer back to m_pMarkNodesParent children, for rendering
+            m_pMarkNodesParent->appendChildNode(pMarkNodeGraphics->detachNode());
+
             visible = true;
         }
 
         // Check if the range needs to be displayed.
         if (samplePosition != sampleEndPosition && sampleEndPosition != Cue::kNoPosition) {
             DEBUG_ASSERT(samplePosition < sampleEndPosition);
-            const float currentMarkEndPoint = static_cast<
-                    float>(
-                    m_waveformRenderer
-                            ->transformSamplePositionInRendererWorld(
-                                    sampleEndPosition, positionType));
-
-            if (visible || currentMarkEndPoint > 0) {
+            const float currentMarkEndPos = static_cast<float>(
+                    m_waveformRenderer->transformSamplePositionInRendererWorld(
+                            sampleEndPosition, positionType));
+            if (visible || currentMarkEndPos > 0.f) {
                 QColor color = pMark->fillColor();
                 color.setAlphaF(0.4f);
 
-                drawMark(matrix,
-                        QRectF(QPointF(currentMarkPoint, 0),
-                                QPointF(currentMarkEndPoint,
-                                        m_waveformRenderer
-                                                ->getBreadth())),
+                // Reuse, or create new when needed
+                if (!pRangeChild) {
+                    auto pNode = std::make_unique<GeometryNode>();
+                    pNode->initForRectangles<RGBAMaterial>(2);
+                    pRangeChild = pNode.get();
+                    m_pRangeNodesParent->appendChildNode(std::move(pNode));
+                }
+
+                updateRangeNode(pRangeChild,
+                        QRectF(QPointF(roundToPixel(currentMarkPos), 0.f),
+                                QPointF(roundToPixel(currentMarkEndPos),
+                                        roundToPixel(m_waveformRenderer->getBreadth()))),
                         color);
+
                 visible = true;
+                pRangeChild = static_cast<GeometryNode*>(pRangeChild->nextSibling());
             }
         }
 
@@ -304,30 +346,36 @@ void allshader::WaveformRenderMark::paintGL() {
                             pMark, static_cast<int>(drawOffset)});
         }
     }
+
+    // Remove unused nodes
+    while (pRangeChild) {
+        auto pNode = m_pRangeNodesParent->detachChildNode(pRangeChild);
+        pRangeChild = static_cast<GeometryNode*>(pRangeChild->nextSibling());
+    }
+
     m_waveformRenderer->setMarkPositions(marksOnScreen);
 
-    const float currentMarkPoint =
-            std::round(static_cast<float>(
-                               m_waveformRenderer->getPlayMarkerPosition() *
-                               m_waveformRenderer->getLength()) *
-                    devicePixelRatio) /
-            devicePixelRatio;
-
-    if (m_playPosMarkTexture.isStorageAllocated()) {
-        const float markHalfWidth = m_playPosMarkTexture.width() / devicePixelRatio / 2.f;
-        const float drawOffset = currentMarkPoint - markHalfWidth;
-
-        drawTexture(matrix, drawOffset, 0.f, &m_playPosMarkTexture);
+    const float playMarkerPos = static_cast<float>(m_waveformRenderer->getPlayMarkerPosition() *
+            m_waveformRenderer->getLength());
+    {
+        const float drawOffset = roundToPixel(playMarkerPos + kPlayPosOffset);
+        TexturedVertexUpdater vertexUpdater{
+                m_pPlayPosNode->geometry()
+                        .vertexDataAs<Geometry::TexturedPoint2D>()};
+        vertexUpdater.addRectangle({drawOffset, 0.f},
+                {drawOffset + kPlayPosWidth, static_cast<float>(m_waveformRenderer->getBreadth())},
+                {0.f, 0.f},
+                {1.f, 1.f});
     }
 
     if (WaveformWidgetFactory::instance()->getUntilMarkShowBeats() ||
             WaveformWidgetFactory::instance()->getUntilMarkShowTime()) {
         updateUntilMark(playPosition, nextMarkPosition);
-        drawUntilMark(matrix, currentMarkPoint + 20);
+        updateDigitsNodeForUntilMark(roundToPixel(playMarkerPos + 20.f));
     }
 }
 
-void allshader::WaveformRenderMark::drawUntilMark(const QMatrix4x4& matrix, float x) {
+void allshader::WaveformRenderMark::updateDigitsNodeForUntilMark(float x) {
     const bool untilMarkShowBeats = WaveformWidgetFactory::instance()->getUntilMarkShowBeats();
     const bool untilMarkShowTime = WaveformWidgetFactory::instance()->getUntilMarkShowTime();
     const auto untilMarkAlign = WaveformWidgetFactory::instance()->getUntilMarkAlign();
@@ -340,14 +388,16 @@ void allshader::WaveformRenderMark::drawUntilMark(const QMatrix4x4& matrix, floa
                                                      // height
     const auto untilMarkMaxHeightForText = getMaxHeightForText(untilMarkTextHeightLimit);
 
-    m_digitsRenderer.updateTexture(untilMarkTextPointSize,
+    m_pDigitsRenderNode->updateTexture(m_waveformRenderer->getContext(),
+            untilMarkTextPointSize,
             untilMarkMaxHeightForText,
             m_waveformRenderer->getDevicePixelRatio());
 
     if (m_timeUntilMark == 0.0) {
+        m_pDigitsRenderNode->clear();
         return;
     }
-    const float ch = m_digitsRenderer.height();
+    const float ch = m_pDigitsRenderNode->height();
 
     float y = untilMarkAlign == Qt::AlignTop ? 0.f
             : untilMarkAlign == Qt::AlignBottom
@@ -368,39 +418,33 @@ void allshader::WaveformRenderMark::drawUntilMark(const QMatrix4x4& matrix, floa
         }
     }
 
-    if (untilMarkShowBeats) {
-        const auto w = m_digitsRenderer.draw(matrix,
-                x,
-                y,
-                QString::number(m_beatsUntilMark));
-        if (multiLine) {
-            y += ch;
-        } else {
-            x += w + ch * 0.75f;
-        }
-    }
-
-    if (untilMarkShowTime) {
-        m_digitsRenderer.draw(matrix,
-                x,
-                y,
-                timeSecToString(m_timeUntilMark));
-    }
+    m_pDigitsRenderNode->update(
+            x,
+            y,
+            multiLine,
+            untilMarkShowBeats ? QString::number(m_beatsUntilMark) : QString{},
+            untilMarkShowTime ? timeSecToString(m_timeUntilMark) : QString{});
 }
 
 // Generate the texture used to draw the play position marker.
 // Note that in the legacy waveform widgets this is drawn directly
 // in the WaveformWidgetRenderer itself. Doing it here is cleaner.
-void allshader::WaveformRenderMark::updatePlayPosMarkTexture() {
+void allshader::WaveformRenderMark::updatePlayPosMarkTexture(rendergraph::Context* pContext) {
     float imgwidth;
     float imgheight;
 
     const float height = m_waveformRenderer->getBreadth();
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
 
+    if (height == m_playPosHeight && devicePixelRatio == m_playPosDevicePixelRatio) {
+        return;
+    }
+    m_playPosHeight = height;
+    m_playPosDevicePixelRatio = devicePixelRatio;
+
     const float lineX = 5.5f;
 
-    imgwidth = 11.f;
+    imgwidth = kPlayPosWidth;
     imgheight = height;
 
     const QSize size{static_cast<int>(std::lround(imgwidth * devicePixelRatio)),
@@ -457,7 +501,8 @@ void allshader::WaveformRenderMark::updatePlayPosMarkTexture() {
     }
     painter.end();
 
-    m_playPosMarkTexture.setData(image);
+    dynamic_cast<TextureMaterial&>(m_pPlayPosNode->material())
+            .setTexture(std::make_unique<Texture>(pContext, image));
 }
 
 void allshader::WaveformRenderMark::drawTriangle(QPainter* painter,
@@ -474,15 +519,19 @@ void allshader::WaveformRenderMark::drawTriangle(QPainter* painter,
     painter->fillPath(triangle, fillColor);
 }
 
-void allshader::WaveformRenderMark::resizeGL(int, int) {
-    // Will create textures so requires OpenGL context
-    updateMarkImages();
-    updatePlayPosMarkTexture();
-}
-
 void allshader::WaveformRenderMark::updateMarkImage(WaveformMarkPointer pMark) {
-    pMark->m_pGraphics = std::make_unique<TextureGraphics>(
-            pMark->generateImage(m_waveformRenderer->getDevicePixelRatio()));
+    if (!pMark->m_pGraphics) {
+        pMark->m_pGraphics =
+                std::make_unique<WaveformMarkNodeGraphics>(pMark.get(),
+                        m_waveformRenderer->getContext(),
+                        pMark->generateImage(
+                                m_waveformRenderer->getDevicePixelRatio()));
+    } else {
+        auto pGraphics = static_cast<WaveformMarkNodeGraphics*>(pMark->m_pGraphics.get());
+        pGraphics->updateTexture(m_waveformRenderer->getContext(),
+                pMark->generateImage(
+                        m_waveformRenderer->getDevicePixelRatio()));
+    }
 }
 
 void allshader::WaveformRenderMark::updateUntilMark(

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -2,40 +2,42 @@
 
 #include <QColor>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/rgbashader.h"
-#include "shaders/textureshader.h"
-#include "util/opengltexture2d.h"
-#include "waveform/renderers/allshader/digitsrenderer.h"
+#include "rendergraph/geometrynode.h"
+#include "rendergraph/node.h"
 #include "waveform/renderers/waveformrendermarkbase.h"
 
 class QDomNode;
-class SkinContext;
-class QOpenGLTexture;
+
+namespace rendergraph {
+class GeometryNode;
+class Context;
+} // namespace rendergraph
 
 namespace allshader {
+class DigitsRenderNode;
 class WaveformRenderMark;
-}
+} // namespace allshader
 
-class allshader::WaveformRenderMark final
-        : public ::WaveformRenderMarkBase,
-          public rendergraph::OpenGLNode {
+class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
+                                      public rendergraph::Node {
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
                     ::WaveformRendererAbstract::Play);
 
-    bool init() override;
-    void draw(QPainter* painter, QPaintEvent* event) override;
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
 
-    void initializeGL() override;
-    void paintGL() override;
-    void resizeGL(int w, int h) override;
+    bool init() override;
+
+    void update();
+
+    bool isSubtreeBlocked() const override;
 
   private:
     void updateMarkImage(WaveformMarkPointer pMark) override;
 
-    void updatePlayPosMarkTexture();
+    void updatePlayPosMarkTexture(rendergraph::Context* pContext);
 
     void drawTriangle(QPainter* painter,
             const QBrush& fillColor,
@@ -43,16 +45,13 @@ class allshader::WaveformRenderMark final
             QPointF p2,
             QPointF p3);
 
-    void drawMark(const QMatrix4x4& matrix, const QRectF& rect, QColor color);
-    void drawTexture(const QMatrix4x4& matrix, float x, float y, QOpenGLTexture* texture);
     void updateUntilMark(double playPosition, double markerPosition);
-    void drawUntilMark(const QMatrix4x4& matrix, float x);
+    void updateDigitsNodeForUntilMark(float x);
     float getMaxHeightForText(float proportion) const;
+    void updateRangeNode(rendergraph::GeometryNode* pNode,
+            const QRectF& rect,
+            QColor color);
 
-    mixxx::RGBAShader m_rgbaShader;
-    mixxx::TextureShader m_textureShader;
-    OpenGLTexture2D m_playPosMarkTexture;
-    DigitsRenderer m_digitsRenderer;
     int m_beatsUntilMark;
     double m_timeUntilMark;
     double m_currentBeatPosition;
@@ -60,6 +59,15 @@ class allshader::WaveformRenderMark final
     std::unique_ptr<ControlProxy> m_pTimeRemainingControl;
 
     bool m_isSlipRenderer;
+
+    rendergraph::Node* m_pRangeNodesParent{};
+    rendergraph::Node* m_pMarkNodesParent{};
+
+    rendergraph::GeometryNode* m_pPlayPosNode;
+    float m_playPosHeight;
+    float m_playPosDevicePixelRatio;
+
+    DigitsRenderNode* m_pDigitsRenderNode{};
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -100,6 +100,7 @@ WaveformMark::WaveformMark(const QString& group,
         const WaveformSignalColors& signalColors,
         int hotCue)
         : m_linePosition{},
+          m_offset{},
           m_breadth{},
           m_level{},
           m_iPriority(priority),
@@ -278,6 +279,15 @@ struct MarkerGeometry {
         const Qt::Alignment alignH = align & Qt::AlignHorizontal_Mask;
         const Qt::Alignment alignV = align & Qt::AlignVertical_Mask;
         const bool alignHCenter{alignH == Qt::AlignHCenter};
+
+        // The image width is the label rect width + 1, so that the label rect
+        // left and right positions can be at an integer + 0.5. This is so that
+        // the label rect is drawn at an exact pixel positions.
+        //
+        // Likewise, the line position also has to fall on an integer + 0.5.
+        // When center aligning, the image width has to be odd, so that the
+        // center is an integer + 0.5. For the image width to be odd, to
+        // label rect width has to be even.
         const qreal widthRounding{alignHCenter ? 2.f : 1.f};
 
         m_labelRect = QRectF{0.f,
@@ -286,17 +296,9 @@ struct MarkerGeometry {
                         widthRounding,
                 std::ceil(capHeight + 2.f * margin)};
 
-        m_imageSize = QSizeF{alignHCenter ? m_labelRect.width() + 1.f
-                                          : 2.f * m_labelRect.width() + 1.f,
-                breadth};
+        m_imageSize = QSizeF{m_labelRect.width() + 1.f, breadth};
 
-        if (alignH == Qt::AlignHCenter) {
-            m_labelRect.moveLeft((m_imageSize.width() - m_labelRect.width()) / 2.f);
-        } else if (alignH == Qt::AlignRight) {
-            m_labelRect.moveRight(m_imageSize.width() - 0.5f);
-        } else {
-            m_labelRect.moveLeft(0.5f);
-        }
+        m_labelRect.moveLeft(0.5f);
 
         const float increment = overlappingMarkerIncrement(
                 static_cast<float>(m_labelRect.height()), breadth);
@@ -378,22 +380,41 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
 
     painter.setWorldMatrixEnabled(false);
 
-    // Draw marker lines
-    const auto hcenter = markerGeometry.m_imageSize.width() / 2.f;
-    m_linePosition = static_cast<float>(hcenter);
+    const Qt::Alignment alignH = m_align & Qt::AlignHorizontal_Mask;
+    const float imgw = static_cast<float>(markerGeometry.m_imageSize.width());
+    switch (alignH) {
+    case Qt::AlignHCenter:
+        m_linePosition = imgw / 2.f;
+        m_offset = -(imgw - 1.f) / 2.f;
+        break;
+    case Qt::AlignLeft:
+        m_linePosition = imgw - 1.5f;
+        m_offset = -imgw + 2.f;
+        break;
+    case Qt::AlignRight:
+    default:
+        m_linePosition = 1.5f;
+        m_offset = -1.f;
+        break;
+    }
+
+    // Note: linePos has to be at integer + 0.5 to draw correctly
+    const float linePos = m_linePosition;
+    [[maybe_unused]] const float epsilon = 1e-6f;
+    DEBUG_ASSERT(std::abs(linePos - std::floor(linePos) - 0.5) < epsilon);
 
     // Draw the center line
     painter.setPen(fillColor());
-    painter.drawLine(QLineF(hcenter, 0.f, hcenter, markerGeometry.m_imageSize.height()));
+    painter.drawLine(QLineF(linePos, 0.f, linePos, markerGeometry.m_imageSize.height()));
 
     painter.setPen(borderColor());
-    painter.drawLine(QLineF(hcenter - 1.f,
+    painter.drawLine(QLineF(linePos - 1.f,
             0.f,
-            hcenter - 1.f,
+            linePos - 1.f,
             markerGeometry.m_imageSize.height()));
-    painter.drawLine(QLineF(hcenter + 1.f,
+    painter.drawLine(QLineF(linePos + 1.f,
             0.f,
-            hcenter + 1.f,
+            linePos + 1.f,
             markerGeometry.m_imageSize.height()));
 
     if (useIcon || label.length() != 0) {

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -5,10 +5,10 @@
 
 #include "control/controlproxy.h"
 #include "track/cue.h"
+#include "waveform/renderers/waveformsignalcolors.h"
 #include "waveform/waveformmarklabel.h"
 
 class SkinContext;
-class WaveformSignalColors;
 class QOpenGLTexture;
 
 namespace allshader {
@@ -36,6 +36,10 @@ class WaveformMark {
     // Disable copying
     WaveformMark(const WaveformMark&) = delete;
     WaveformMark& operator=(const WaveformMark&) = delete;
+
+    float getOffset() const {
+        return m_offset;
+    }
 
     int getHotCue() const {
         return m_iHotCue;
@@ -158,6 +162,7 @@ class WaveformMark {
     QString m_iconPath;
 
     float m_linePosition;
+    float m_offset;
     float m_breadth;
 
     // When there are overlapping marks, level is increased for each overlapping mark,

--- a/src/waveform/renderers/waveformmarkrange.h
+++ b/src/waveform/renderers/waveformmarkrange.h
@@ -56,7 +56,7 @@ class WaveformMarkRange {
     WaveformMarkLabel m_durationLabel;
 
   private:
-    void generateImage(int weidth, int height);
+    void generateImage(int width, int height);
 
     std::unique_ptr<ControlProxy> m_markStartPointControl;
     std::unique_ptr<ControlProxy> m_markEndPointControl;

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -37,17 +37,13 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                     m_waveformRenderer->transformSamplePositionInRendererWorld(samplePosition);
             const double sampleEndPosition = pMark->getSampleEndPosition();
             if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-                // Pixmaps are expected to have the mark stroke at the center,
-                // and preferably have an odd width in order to have the stroke
-                // exactly at the sample position.
-                const int markHalfWidth =
-                        static_cast<int>(image.width() / 2.0 /
-                                m_waveformRenderer->getDevicePixelRatio());
-                const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfWidth;
+                const int markWidth = std::lround(image.width() /
+                        m_waveformRenderer->getDevicePixelRatio());
+                const int drawOffset = std::lround(currentMarkPoint + pMark->getOffset());
 
                 bool visible = false;
                 // Check if the current point needs to be displayed.
-                if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
+                if (drawOffset > -markWidth && drawOffset < m_waveformRenderer->getWidth()) {
                     painter->drawImage(drawOffset, 0, image);
                     visible = true;
                 }
@@ -84,16 +80,15 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                                     pMark, drawOffset});
                 }
             } else {
-                const int markHalfHeight =
-                        static_cast<int>(image.height() / 2.0 /
-                                m_waveformRenderer->getDevicePixelRatio());
-                const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfHeight;
+                const int markHeight = std::lroundf(image.height() /
+                        m_waveformRenderer->getDevicePixelRatio());
+                const int drawOffset =
+                        std::lround(static_cast<float>(currentMarkPoint) +
+                                pMark->getOffset());
 
                 bool visible = false;
                 // Check if the current point needs to be displayed.
-                if (currentMarkPoint > -markHalfHeight &&
-                        currentMarkPoint < m_waveformRenderer->getHeight() +
-                                        markHalfHeight) {
+                if (drawOffset > -markHeight && drawOffset < m_waveformRenderer->getHeight()) {
                     painter->drawImage(0, drawOffset, image);
                     visible = true;
                 }

--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -14,9 +14,13 @@ WaveformRenderMarkBase::WaveformRenderMarkBase(
 void WaveformRenderMarkBase::setup(const QDomNode& node, const SkinContext& context) {
     WaveformSignalColors signalColors = *m_waveformRenderer->getWaveformSignalColors();
     m_marks.setup(m_waveformRenderer->getGroup(), node, context, signalColors);
+}
+
+bool WaveformRenderMarkBase::init() {
     m_marks.connectSamplePositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
     m_marks.connectSampleEndPositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
     m_marks.connectVisibleChanged(this, &WaveformRenderMarkBase::onMarkChanged);
+    return true;
 }
 
 void WaveformRenderMarkBase::onSetTrack() {

--- a/src/waveform/renderers/waveformrendermarkbase.h
+++ b/src/waveform/renderers/waveformrendermarkbase.h
@@ -17,6 +17,8 @@ class WaveformRenderMarkBase : public QObject, public WaveformRendererAbstract {
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 
+    bool init() override;
+
     // Called when a new track is loaded.
     void onSetTrack() override;
 

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -136,6 +136,7 @@ void WaveformWidget::paintGL() {
     // opacity of 0.f effectively skips the subtree rendering
     m_pOpacityNode->setOpacity(shouldOnlyDrawBackground() ? 0.f : 1.f);
 
+    m_pWaveformRenderMark->update();
     m_pWaveformRenderMarkRange->update();
 
     m_pEngine->preprocess();


### PR DESCRIPTION
I have split the rendergraph PR https://github.com/mixxxdj/mixxx/pull/13599 into muliple PRs

https://github.com/m0dB/mixxx/pull/new/rg-rendergraph
https://github.com/m0dB/mixxx/pull/new/rg-use-opengl-node
https://github.com/m0dB/mixxx/pull/new/rg-shaders
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendererendoftrack
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendererpreroll
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-markrange-beat
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendermark 
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-signals
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-stem-slip
https://github.com/m0dB/mixxx/pull/new/rg-cleanup

These should be merged in order. I set the base of each PR to the previous PR. Once the previous PR has been merged, it should be retargeted to main.