### PR TITLE
use geometrynodes for waveformrender markrange and beat

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -2,34 +2,49 @@
 
 #include <QDomNode>
 
+#include "rendergraph/geometry.h"
+#include "rendergraph/material/unicolormaterial.h"
+#include "rendergraph/vertexupdaters/vertexupdater.h"
 #include "skin/legacy/skincontext.h"
 #include "track/track.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "widget/wskincolor.h"
+
+using namespace rendergraph;
 
 namespace allshader {
 
 WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
         ::WaveformRendererAbstract::PositionSource type)
-        : WaveformRenderer(waveformWidget),
+        : ::WaveformRendererAbstract(waveformWidget),
           m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
+    initForRectangles<UniColorMaterial>(0);
+    setUsePreprocess(true);
 }
 
-void WaveformRenderBeat::initializeGL() {
-    m_shader.init();
-}
-
-void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& context) {
-    m_color = QColor(context.selectString(node, "BeatColor"));
+void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& skinContext) {
+    m_color = QColor(skinContext.selectString(node, "BeatColor"));
     m_color = WSkinColor::getCorrectColor(m_color).toRgb();
 }
 
-void WaveformRenderBeat::paintGL() {
-    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* event) {
+    Q_UNUSED(painter);
+    Q_UNUSED(event);
+    DEBUG_ASSERT(false);
+}
+
+void WaveformRenderBeat::preprocess() {
+    if (!preprocessInner()) {
+        geometry().allocate(0);
+        markDirtyGeometry();
+    }
+}
+
+bool WaveformRenderBeat::preprocessInner() {
+    const TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
 
     if (!trackInfo || (m_isSlipRenderer && !m_waveformRenderer->isSlipActive())) {
-        return;
+        return false;
     }
 
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
@@ -37,24 +52,21 @@ void WaveformRenderBeat::paintGL() {
 
     mixxx::BeatsPointer trackBeats = trackInfo->getBeats();
     if (!trackBeats) {
-        return;
+        return false;
     }
 
     int alpha = m_waveformRenderer->getBeatGridAlpha();
     if (alpha == 0) {
-        return;
+        return false;
     }
 
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
 
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
     m_color.setAlphaF(alpha / 100.0f);
 
     const double trackSamples = m_waveformRenderer->getTrackSamples();
-    if (trackSamples <= 0) {
-        return;
+    if (trackSamples <= 0.0) {
+        return false;
     }
 
     const double firstDisplayedPosition =
@@ -68,7 +80,7 @@ void WaveformRenderBeat::paintGL() {
             lastDisplayedPosition * trackSamples);
 
     if (!startPosition.isValid() || !endPosition.isValid()) {
-        return;
+        return false;
     }
 
     const float rendererBreadth = m_waveformRenderer->getBreadth();
@@ -87,8 +99,9 @@ void WaveformRenderBeat::paintGL() {
     }
 
     const int reserved = numBeatsInRange * numVerticesPerLine;
-    m_vertices.clear();
-    m_vertices.reserve(reserved);
+    geometry().allocate(reserved);
+
+    VertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::Point2D>()};
 
     for (auto it = trackBeats->iteratorFrom(startPosition);
             it != trackBeats->cend() && *it <= endPosition;
@@ -103,33 +116,17 @@ void WaveformRenderBeat::paintGL() {
         const float x1 = static_cast<float>(xBeatPoint);
         const float x2 = x1 + 1.f;
 
-        m_vertices.addRectangle(x1,
-                0.f,
-                x2,
-                m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth);
+        vertexUpdater.addRectangle({x1, 0.f},
+                {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
     }
+    markDirtyGeometry();
 
-    DEBUG_ASSERT(reserved == m_vertices.size());
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
 
-    const int positionLocation = m_shader.positionLocation();
-    const int matrixLocation = m_shader.matrixLocation();
-    const int colorLocation = m_shader.colorLocation();
+    material().setUniform(1, m_color);
+    markDirtyMaterial();
 
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
-
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, m_vertices.constData(), 2);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-    m_shader.setUniformValue(colorLocation, m_color);
-
-    glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.release();
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrenderbeat.h
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include <QColor>
+#include <memory>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/unicolorshader.h"
+#include "rendergraph/geometrynode.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
-#include "waveform/renderers/allshader/waveformrenderer.h"
+#include "waveform/renderers/waveformrendererabstract.h"
 
 class QDomNode;
 class SkinContext;
@@ -16,23 +15,26 @@ class WaveformRenderBeat;
 }
 
 class allshader::WaveformRenderBeat final
-        : public allshader::WaveformRenderer,
-          public rendergraph::OpenGLNode {
+        : public ::WaveformRendererAbstract,
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
                     ::WaveformRendererAbstract::Play);
 
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
+
     void setup(const QDomNode& node, const SkinContext& skinContext) override;
-    void paintGL() override;
-    void initializeGL() override;
+
+    // Virtuals for rendergraph::Node
+    void preprocess() override;
 
   private:
-    mixxx::UnicolorShader m_shader;
     QColor m_color;
-    VertexData m_vertices;
-
     bool m_isSlipRenderer;
+
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderBeat);
 };

--- a/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
@@ -1,70 +1,46 @@
 #include "waveform/renderers/allshader/waveformrendermarkrange.h"
 
+#include "rendergraph/geometry.h"
+#include "rendergraph/geometrynode.h"
+#include "rendergraph/material/unicolormaterial.h"
+#include "rendergraph/vertexupdaters/vertexupdater.h"
 #include "skin/legacy/skincontext.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 
-allshader::WaveformRenderMarkRange::WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidget)
-        : WaveformRenderer(waveformWidget) {
+using namespace rendergraph;
+
+namespace allshader {
+
+WaveformRenderMarkRange::WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidget)
+        : ::WaveformRendererAbstract(waveformWidget) {
 }
 
-void allshader::WaveformRenderMarkRange::initializeGL() {
-    m_shader.init();
-}
-
-void allshader::WaveformRenderMarkRange::fillRect(
-        const QRectF& rect, QColor color) {
-    const float posx1 = static_cast<float>(rect.x());
-    const float posx2 = static_cast<float>(rect.x() + rect.width());
-    const float posy1 = static_cast<float>(rect.y());
-    const float posy2 = static_cast<float>(rect.y() + rect.height());
-
-    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
-
-    const int colorLocation = m_shader.colorLocation();
-    const int positionLocation = m_shader.positionLocation();
-
-    m_shader.setUniformValue(colorLocation, color);
-
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, posarray, 2);
-
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-}
-
-void allshader::WaveformRenderMarkRange::setup(const QDomNode& node, const SkinContext& context) {
+void WaveformRenderMarkRange::setup(const QDomNode& node, const SkinContext& skinContext) {
     m_markRanges.clear();
-    m_markRanges.reserve(1);
 
     QDomNode child = node.firstChild();
     while (!child.isNull()) {
         if (child.nodeName() == "MarkRange") {
-            m_markRanges.push_back(
-                    WaveformMarkRange(
-                            m_waveformRenderer->getGroup(),
-                            child,
-                            context,
-                            *m_waveformRenderer->getWaveformSignalColors()));
+            addRange(WaveformMarkRange(
+                    m_waveformRenderer->getGroup(),
+                    child,
+                    skinContext,
+                    *m_waveformRenderer->getWaveformSignalColors()));
         }
         child = child.nextSibling();
     }
 }
 
-void allshader::WaveformRenderMarkRange::paintGL() {
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+void WaveformRenderMarkRange::draw(QPainter* painter, QPaintEvent* event) {
+    Q_UNUSED(painter);
+    Q_UNUSED(event);
+    DEBUG_ASSERT(false);
+}
 
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
+void WaveformRenderMarkRange::update() {
+    GeometryNode* pChild = static_cast<GeometryNode*>(firstChild());
 
-    const int positionLocation = m_shader.positionLocation();
-    const int matrixLocation = m_shader.matrixLocation();
-
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-
-    for (auto&& markRange : m_markRanges) {
+    for (const auto& markRange : m_markRanges) {
         // If the mark range is not active we should not draw it.
         if (!markRange.active()) {
             continue;
@@ -88,8 +64,6 @@ void allshader::WaveformRenderMarkRange::paintGL() {
         startPosition = std::floor(startPosition);
         endPosition = std::floor(endPosition);
 
-        const double span = std::max(endPosition - startPosition, 1.0);
-
         // range not in the current display
         if (startPosition > m_waveformRenderer->getLength() || endPosition < 0) {
             continue;
@@ -98,8 +72,36 @@ void allshader::WaveformRenderMarkRange::paintGL() {
         QColor color = markRange.enabled() ? markRange.m_activeColor : markRange.m_disabledColor;
         color.setAlphaF(0.3f);
 
-        fillRect(QRectF(startPosition, 0, span, m_waveformRenderer->getBreadth()), color);
+        if (!pChild) {
+            auto pNode = std::make_unique<GeometryNode>();
+            pChild = pNode.get();
+            pChild->initForRectangles<UniColorMaterial>(1);
+            appendChildNode(std::move(pNode));
+        }
+
+        updateNode(pChild,
+                color,
+                {static_cast<float>(startPosition), 0.f},
+                {static_cast<float>(endPosition) + 1.f,
+                        static_cast<float>(m_waveformRenderer->getBreadth())});
+
+        pChild = static_cast<GeometryNode*>(pChild->nextSibling());
     }
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.release();
+    while (pChild) {
+        auto pNode = detachChildNode(pChild);
+        pChild = static_cast<GeometryNode*>(pChild->nextSibling());
+    }
 }
+
+void WaveformRenderMarkRange::updateNode(GeometryNode* pChild,
+        QColor color,
+        QVector2D lt,
+        QVector2D rb) {
+    VertexUpdater vertexUpdater{pChild->geometry().vertexDataAs<Geometry::Point2D>()};
+    vertexUpdater.addRectangle(lt, rb);
+    pChild->material().setUniform(1, color);
+    pChild->markDirtyGeometry();
+    pChild->markDirtyMaterial();
+}
+
+} // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendermarkrange.h
+++ b/src/waveform/renderers/allshader/waveformrendermarkrange.h
@@ -1,36 +1,46 @@
 #pragma once
 
 #include <QColor>
-#include <vector>
+#include <QVector2D>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/unicolorshader.h"
+#include "rendergraph/node.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/waveformrenderer.h"
 #include "waveform/renderers/waveformmarkrange.h"
+#include "waveform/renderers/waveformrendererabstract.h"
 
 class QDomNode;
 class SkinContext;
 
+namespace rendergraph {
+class GeometryNode;
+} // namespace rendergraph
+
 namespace allshader {
 class WaveformRenderMarkRange;
-}
+} // namespace allshader
 
-class allshader::WaveformRenderMarkRange final
-        : public allshader::WaveformRenderer,
-          public rendergraph::OpenGLNode {
+class allshader::WaveformRenderMarkRange final : public ::WaveformRendererAbstract,
+                                                 public rendergraph::Node {
   public:
     explicit WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidget);
 
+    void addRange(WaveformMarkRange&& range) {
+        m_markRanges.push_back(std::move(range));
+    }
+
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
+
     void setup(const QDomNode& node, const SkinContext& skinContext) override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    void update();
 
   private:
-    void fillRect(const QRectF& rect, QColor color);
+    void updateNode(rendergraph::GeometryNode* pChild,
+            QColor color,
+            QVector2D lt,
+            QVector2D rb);
 
-    mixxx::UnicolorShader m_shader;
     std::vector<WaveformMarkRange> m_markRanges;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMarkRange);

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -136,6 +136,8 @@ void WaveformWidget::paintGL() {
     // opacity of 0.f effectively skips the subtree rendering
     m_pOpacityNode->setOpacity(shouldOnlyDrawBackground() ? 0.f : 1.f);
 
+    m_pWaveformRenderMarkRange->update();
+
     m_pEngine->preprocess();
     m_pEngine->render();
 }


### PR DESCRIPTION
I have split the rendergraph PR https://github.com/mixxxdj/mixxx/pull/13599 into muliple PRs

https://github.com/m0dB/mixxx/pull/new/rg-rendergraph
https://github.com/m0dB/mixxx/pull/new/rg-use-opengl-node
https://github.com/m0dB/mixxx/pull/new/rg-shaders
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendererendoftrack
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendererpreroll
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-markrange-beat
https://github.com/m0dB/mixxx/pull/new/rg-waveformrendermark 
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-signals
https://github.com/m0dB/mixxx/pull/new/rg-waveformrender-stem-slip
https://github.com/m0dB/mixxx/pull/new/rg-cleanup

These should be merged in order. I set the base of each PR to the previous PR. Once the previous PR has been merged, it should be retargeted to main.